### PR TITLE
WIP 179 docs support cuda 100 with tf200

### DIFF
--- a/deepreg/model/layer_util.py
+++ b/deepreg/model/layer_util.py
@@ -224,7 +224,7 @@ def resample(vol, loc, interpolation="linear"):
         raise ValueError("resample supports only linear interpolation")
 
     # init
-    batch_size = vol.shape[0]
+    batch_size = tf.shape(vol)[0]
     loc_shape = loc.shape[1:-1]
     dim_vol = loc.shape[-1]  # dimension of vol
     if dim_vol == len(vol.shape) - 1:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "matplotlib",
         "argparse",
         "tqdm",
-        "tensorflow==2.2",
+        "tensorflow>=2.0",
         "pytest>=4.6",
         "pytest-cov",
         "pytest-dependency",


### PR DESCRIPTION
# Description

Fixes #179 

Actually there are many things to test under tf2.0
1. train and predict with CPU, manually
2. train and predict with one GPU, manually
3. train and predict with two GPUs, manually
4. pytest with CPU
5. pytest with one GPU
6. pytest with two GPUs

So we will need to support configurable pytest.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
