### PR TITLE
Issue #189: fix random seed to make test deterministic

### DIFF
--- a/test/unit/test_unpaired_data_loader.py
+++ b/test/unit/test_unpaired_data_loader.py
@@ -20,44 +20,40 @@ def test_sample_index_generator():
     """
     Test to check the randomness and deterministic index generator for train/test respectively.
     """
+    image_shape = (64, 64, 60)
+
     for key_file_loader, file_loader in FileLoaderDict.items():
         for split in ["train", "test"]:
             data_dir_path = join(DataPaths[key_file_loader], split)
-            image_shape = (64, 64, 60)
-            common_args = dict(
-                file_loader=file_loader,
-                labeled=True,
-                sample_label="all",
-                seed=None if split == "train" else 0,
-            )
+            indices_to_compare = []
 
-            data_loader = UnpairedDataLoader(
-                data_dir_path=data_dir_path, image_shape=image_shape, **common_args
-            )
+            for seed in [0, 1, 0]:
+                data_loader = UnpairedDataLoader(
+                    data_dir_path=data_dir_path,
+                    image_shape=image_shape,
+                    file_loader=file_loader,
+                    labeled=True,
+                    sample_label="all",
+                    seed=seed,
+                )
 
-            num_samples = data_loader.num_samples
-            index_array = np.zeros((2 * num_samples, 2))
-            for epoch in range(2):
-                for it_indices, indices in enumerate(
-                    data_loader.sample_index_generator()
-                ):
-                    image_indices = indices[2]
-                    index_array[
-                        2 * it_indices : 2 * (it_indices + 1), epoch
-                    ] = image_indices
-                    if it_indices >= (num_samples - 1):
-                        break
+                data_indices = []
+                for (
+                    moving_index,
+                    fixed_index,
+                    indices,
+                ) in data_loader.sample_index_generator():
+                    assert isinstance(moving_index, int)
+                    assert isinstance(fixed_index, int)
+                    assert isinstance(indices, list)
+                    data_indices += indices
 
-            reference_index, moving_index, image_list = next(
-                data_loader.sample_index_generator()
-            )
-            assert isinstance(reference_index, int)
-            assert isinstance(moving_index, int)
-            assert isinstance(image_list, list)
-            if split == "train":
-                assert np.allclose(index_array[..., 0], index_array[..., 1]) is False
-            elif split == "test":
-                assert np.allclose(index_array[..., 0], index_array[..., 1]) is True
+                indices_to_compare.append(data_indices)
+
+            # test different seeds give different indices
+            assert np.allclose(indices_to_compare[0], indices_to_compare[1]) is False
+            # test same seeds give the same indices
+            assert np.allclose(indices_to_compare[0], indices_to_compare[2]) is True
 
 
 def test_validate_data_files():
@@ -67,7 +63,6 @@ def test_validate_data_files():
     """
     for key_file_loader, file_loader in FileLoaderDict.items():
         for split in ["train", "test"]:
-
             data_dir_path = join(DataPaths[key_file_loader], split)
             image_shape = (64, 64, 60)
             common_args = dict(


### PR DESCRIPTION
# Description

Fixes #189

The test was due to a bug in `sample_index_generator` that different seeds give the same order of data.

So, the main objective of the test should be testing that different seeds give different orders,
which should be irrelevant to the split, "train" or "test".

Thus, I modified the test to test the collected indices are the same for the same seeds and different for different seeds.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
