### PR TITLE
188 bug pytest with gpu cant pass pytest test unit

### DIFF
--- a/deepreg/model/loss/label.py
+++ b/deepreg/model/loss/label.py
@@ -218,7 +218,7 @@ def gauss_kernel1d(sigma: int):
     :return: tensor, shape [range(-3*sigma, 3*sigma + 1)]
     """
     if sigma == 0:
-        return tf.constant(0)
+        return tf.constant(0, tf.float32)
     else:
         tail = int(sigma * 3)
         k = tf.exp([-0.5 * x ** 2 / sigma ** 2 for x in range(-tail, tail + 1)])
@@ -233,7 +233,7 @@ def cauchy_kernel1d(sigma: int):
     :return: tensor, shape [range(-3*sigma, 3*sigma + 1)]
     """
     if sigma == 0:
-        return tf.constant(0)
+        return tf.constant(0, tf.float32)
     else:
         tail = int(sigma * 5)
         k = tf.math.reciprocal([((x / sigma) ** 2 + 1) for x in range(-tail, tail + 1)])

--- a/deepreg/model/loss/label.py
+++ b/deepreg/model/loss/label.py
@@ -209,7 +209,7 @@ def jaccard_index(y_true, y_pred):
     return numerator / denominator
 
 
-def gauss_kernel1d(sigma):
+def gauss_kernel1d(sigma: int):
     """
     Calculates a gaussian kernel.
 
@@ -225,7 +225,7 @@ def gauss_kernel1d(sigma):
         return k / tf.reduce_sum(k)
 
 
-def cauchy_kernel1d(sigma):
+def cauchy_kernel1d(sigma: int):
     """
     Approximating cauchy kernel in 1d.
 
@@ -233,7 +233,7 @@ def cauchy_kernel1d(sigma):
     :return: tensor, shape [range(-3*sigma, 3*sigma + 1)]
     """
     if sigma == 0:
-        return 0
+        return tf.constant(0)
     else:
         tail = int(sigma * 5)
         k = tf.math.reciprocal([((x / sigma) ** 2 + 1) for x in range(-tail, tail + 1)])

--- a/test/unit/test_backbone.py
+++ b/test/unit/test_backbone.py
@@ -111,7 +111,9 @@ def test_call_GlobalNet():
         out_activation="softmax",
     )
     # Pass an input of all zeros
-    inputs = np.zeros((5, im_size[0], im_size[1], im_size[2], out))
+    inputs = tf.constant(
+        np.zeros((5, im_size[0], im_size[1], im_size[2], out), dtype=np.float32)
+    )
     #  Get outputs by calling
     output = global_test.call(inputs)
     #  Expected shape is (5, 1, 2, 3, 3)
@@ -181,7 +183,9 @@ def test_call_LocalNet():
         out_activation="sigmoid",
     )
     # Pass an input of all zeros
-    inputs = np.zeros((5, im_size[0], im_size[1], im_size[2], out))
+    inputs = tf.constant(
+        np.zeros((5, im_size[0], im_size[1], im_size[2], out), dtype=np.float32)
+    )
     #  Get outputs by calling
     output = global_test.call(inputs)
     #  Expected shape is (5, 1, 2, 3, 3)
@@ -252,7 +256,9 @@ def test_call_UNet():
         out_activation="sigmoid",
     )
     # Pass an input of all zeros
-    inputs = np.zeros((5, im_size[0], im_size[1], im_size[2], 3))
+    inputs = tf.constant(
+        np.zeros((5, im_size[0], im_size[1], im_size[2], out), dtype=np.float32)
+    )
     #  Get outputs by calling
     output = global_test.call(inputs)
     #  Expected shape is (5, 1, 2, 3)

--- a/test/unit/test_backbone.py
+++ b/test/unit/test_backbone.py
@@ -55,7 +55,8 @@ def test_init_GlobalNet():
                 [[0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]],
                 [[0.0, 1.0, 0.0], [0.0, 1.0, 1.0], [0.0, 1.0, 2.0]],
             ]
-        ]
+        ],
+        dtype=tf.float32,
     )
     assert assert_tensors_equal(global_test.reference_grid, expected_ref_grid)
 
@@ -63,14 +64,17 @@ def test_init_GlobalNet():
     #  We initialize the expected tensor and initialise another from the
     #  class variable using tf.Variable
     test_tensor_return = tf.convert_to_tensor(
-        [[1.0, 0.0], [0.0, 0.0], [0.0, 1.0], [0.0, 0.0], [0.0, 0.0], [1.0, 0.0]]
+        [[1.0, 0.0], [0.0, 0.0], [0.0, 1.0], [0.0, 0.0], [0.0, 0.0], [1.0, 0.0]],
+        dtype=tf.float32,
     )
     global_return = tf.Variable(
         global_test.transform_initial(shape=[6, 2], dtype=tf.float32)
     )
 
     # Asserting they are equal - Pass
-    assert assert_tensors_equal(test_tensor_return, tf.convert_to_tensor(global_return))
+    assert assert_tensors_equal(
+        test_tensor_return, tf.convert_to_tensor(global_return, dtype=tf.float32)
+    )
 
     # Assert downsample blocks type is correct, Pass
     assert all(

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -28,9 +28,9 @@ def test_gauss_kernel1d_0():
     """
     Testing case where sigma = 0, expect 0 return
     """
-    sigma = 0
+    sigma = tf.constant(0, dtype=tf.float32)
+    expect = tf.constant(0, dtype=tf.float32)
     get = label.gauss_kernel1d(sigma)
-    expect = tf.constant(0)
     assert get == expect
 
 
@@ -41,9 +41,10 @@ def test_gauss_kernel1d_else():
     """
     sigma = 3
     get = tf.cast(label.gauss_kernel1d(sigma), dtype=tf.float32)
-    list_vals = range(-sigma * 3, sigma * 3 + 1)
-    exp = [np.exp(-0.5 * x ** 2 / sigma ** 2) for x in list_vals]
-    expect = tf.convert_to_tensor(exp, dtype=tf.float32)
+    expect = [
+        np.exp(-0.5 * x ** 2 / sigma ** 2) for x in range(-sigma * 3, sigma * 3 + 1)
+    ]
+    expect = tf.convert_to_tensor(expect, dtype=tf.float32)
     expect = expect / tf.reduce_sum(expect)
     assert assertTensorsEqual(get, expect)
 
@@ -52,9 +53,9 @@ def test_cauchy_kernel_0():
     """
     Test case where sigma = 0, expect 0 return.
     """
-    sigma = 0
+    sigma = tf.constant(0, dtype=tf.float32)
+    expect = tf.constant(0, dtype=tf.float32)
     get = label.cauchy_kernel1d(sigma)
-    expect = 0
     assert get == expect
 
 
@@ -65,9 +66,8 @@ def test_cauchy_kernel_else():
     """
     sigma = 3
     get = tf.cast(label.cauchy_kernel1d(sigma), dtype=tf.float32)
-    list_vals = range(-sigma * 5, sigma * 5 + 1)
-    exp = [1 / ((x / sigma) ** 2 + 1) for x in list_vals]
-    expect = tf.convert_to_tensor(exp, dtype=tf.float32)
+    expect = [1 / ((x / sigma) ** 2 + 1) for x in range(-sigma * 5, sigma * 5 + 1)]
+    expect = tf.convert_to_tensor(expect, dtype=tf.float32)
     expect = expect / tf.reduce_sum(expect)
     assert assertTensorsEqual(get, expect)
 
@@ -82,7 +82,7 @@ def test_foreground_prop_binary():
     array_eye = np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
-    expect = [1.0 / 3, 1.0 / 3, 1.0 / 3]
+    expect = tf.convert_to_tensor([1.0 / 3, 1.0 / 3, 1.0 / 3], dtype=tf.float32)
     get = label.foreground_proportion(tensor_eye)
     assert assertTensorsEqual(get, expect)
 
@@ -98,6 +98,7 @@ def test_foreground_prop_simple():
     tensor_eye[:, 0, :, :] = 0.4 * array_eye  #  0
     tensor_eye[:, 1, :, :] = array_eye
     tensor_eye[:, 2, :, :] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
     expect = [54 / (27 * 9), 54 / (27 * 9), 54 / (27 * 9)]
     get = label.foreground_proportion(tensor_eye)
     assert assertTensorsEqual(get, expect)
@@ -111,9 +112,12 @@ def test_jaccard_index():
     array_eye = np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
+
     num = np.array([6, 6, 6])
     denom = np.array([9, 9, 9]) + np.array([6, 6, 6]) - num
 
@@ -130,9 +134,11 @@ def test_dice_not_binary():
     array_eye = np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
 
     num = 2 * np.array([6, 6, 6])
     denom = np.array([9, 9, 9]) + np.array([6, 6, 6])
@@ -150,9 +156,11 @@ def test_dice_binary():
     array_eye = 0.6 * np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
 
     num = 2 * np.array([6, 6, 6])
     denom = np.array([9, 9, 9]) + np.array([6, 6, 6])
@@ -171,9 +179,11 @@ def test_dice_general():
     array_eye = 0.6 * np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
 
     y_prod = np.sum(tensor_eye * tensor_pred, axis=(1, 2, 3))
     y_sum = np.sum(tensor_eye, axis=(1, 2, 3)) + np.sum(tensor_pred, axis=(1, 2, 3))
@@ -194,9 +204,11 @@ def test_weighted_bce():
     array_eye = np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
 
     expect = [1.535057, 1.535057, 1.535057]
     get = label.weighted_binary_cross_entropy(tensor_eye, tensor_pred)
@@ -226,8 +238,10 @@ def test_separable_filter_else():
     array_eye = np.identity(3, dtype=np.float32)
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, :, 0, 0] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
 
     expect = np.ones((3, 3, 3, 3))
+    expect = tf.convert_to_tensor(expect, dtype=tf.float32)
 
     get = label.separable_filter3d(tensor_pred, k)
     assert assertTensorsEqual(get, expect)
@@ -279,9 +293,12 @@ def test_squared_error():
     """
     tensor_mask = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_mask[0, 0, 0, 0] = 1
+    tensor_mask = tf.convert_to_tensor(tensor_mask, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, :, :, :] = 1
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
+
     expect = np.array([26 / 27, 1.0, 1.0])
     get = label.squared_error(tensor_mask, tensor_pred)
     assert assertTensorsEqual(get, expect)
@@ -296,9 +313,11 @@ def test_single_scale_loss_dice():
     array_eye = np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
 
     num = 2 * np.array([6, 6, 6])
     denom = np.array([9, 9, 9]) + np.array([6, 6, 6])
@@ -316,9 +335,11 @@ def test_single_scale_loss_bce():
     array_eye = np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
 
     expect = [1.535057, 1.535057, 1.535057]
     get = label.single_scale_loss(tensor_eye, tensor_pred, "cross-entropy")
@@ -335,9 +356,11 @@ def test_single_scale_loss_dg():
     array_eye = 0.6 * np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
 
     y_prod = np.sum(tensor_eye * tensor_pred, axis=(1, 2, 3))
     y_sum = np.sum(tensor_eye, axis=(1, 2, 3)) + np.sum(tensor_pred, axis=(1, 2, 3))
@@ -357,9 +380,12 @@ def test_single_scale_loss_jacc():
     array_eye = np.identity(3, dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
 
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
+
     num = np.array([6, 6, 6])
     denom = np.array([9, 9, 9]) + np.array([6, 6, 6]) - num
 
@@ -374,11 +400,11 @@ def test_single_scale_loss_mean_sq():
     known mean sq value tensor when passed with
     mean squared arg,
     """
-    tensor_mask = np.zeros((3, 3, 3, 3), dtype=np.float32)
+    tensor_mask = tf.convert_to_tensor(np.zeros((3, 3, 3, 3)), dtype=tf.float32)
     tensor_mask[0, 0, 0, 0] = 1
 
-    tensor_pred = np.ones((3, 3, 3, 3))
-    expect = np.array([26 / 27, 1.0, 1.0])
+    tensor_pred = tf.convert_to_tensor(np.zeros((3, 3, 3, 3)), dtype=tf.float32)
+    expect = tf.convert_to_tensor(np.array([26 / 27, 1.0, 1.0]), dtype=tf.float32)
 
     get = label.single_scale_loss(tensor_mask, tensor_pred, "mean-squared")
     assert assertTensorsEqual(get, expect)
@@ -389,9 +415,8 @@ def test_single_scale_loss_other():
     Test value error raised if non supported
     string passed to the single scale loss function.
     """
-    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
-
-    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
+    tensor_eye = tf.convert_to_tensor(np.zeros((3, 3, 3, 3)), dtype=tf.float32)
+    tensor_pred = tf.convert_to_tensor(np.zeros((3, 3, 3, 3)), dtype=tf.float32)
 
     with pytest.raises(ValueError):
         label.single_scale_loss(tensor_eye, tensor_pred, "random")
@@ -402,8 +427,8 @@ def test_multi_scale_loss_pred_len():
     Test assertion error raised if a wrongly sized tensor
     is passed to the multi-scale loss function.
     """
-    tensor_true = np.zeros((3, 3, 3, 3), dtype=np.float32)
-    tensor_pred = np.zeros((3, 3, 3))
+    tensor_true = tf.convert_to_tensor(np.zeros((3, 3, 3, 3)), dtype=tf.float32)
+    tensor_pred = tf.convert_to_tensor(np.zeros((3, 3, 3)), dtype=tf.float32)
     with pytest.raises(AssertionError):
         label.multi_scale_loss(
             tensor_true, tensor_pred, loss_type="jaccard", loss_scales=[0, 1, 2]
@@ -415,8 +440,8 @@ def test_multi_scale_loss_true_len():
     Test assertion error raised if a wrongly sized tensor
     is passed to the multi-scale loss function.
     """
-    tensor_true = np.zeros((3, 3, 3))
-    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
+    tensor_true = tf.convert_to_tensor(np.zeros((3, 3, 3)), dtype=tf.float32)
+    tensor_pred = tf.convert_to_tensor(np.zeros((3, 3, 3, 3)), dtype=tf.float32)
     with pytest.raises(AssertionError):
         label.multi_scale_loss(
             tensor_true, tensor_pred, loss_type="jaccard", loss_scales=[0, 1, 2]

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -79,8 +79,8 @@ def test_foreground_prop_binary():
     equal to known precomputed tensor.
     Testing with binary case.
     """
-    array_eye = np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
     expect = [1.0 / 3, 1.0 / 3, 1.0 / 3]
     get = label.foreground_proportion(tensor_eye)
@@ -93,8 +93,8 @@ def test_foreground_prop_simple():
     of zeros with some ones and some values below
     one to assert the thresholding works.
     """
-    array_eye = np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, 0, :, :] = 0.4 * array_eye  #  0
     tensor_eye[:, 1, :, :] = array_eye
     tensor_eye[:, 2, :, :] = array_eye
@@ -108,11 +108,11 @@ def test_jaccard_index():
     Testing jaccard index function with computed
     tensor.
     """
-    array_eye = np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
     num = np.array([6, 6, 6])
     denom = np.array([9, 9, 9]) + np.array([6, 6, 6]) - num
@@ -127,11 +127,11 @@ def test_dice_not_binary():
     Testing dice score with binary tensor
     comparing to a precomputed value.
     """
-    array_eye = np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
 
     num = 2 * np.array([6, 6, 6])
@@ -147,11 +147,11 @@ def test_dice_binary():
     Testing dice score with not binary tensor
     to assert thresholding works.
     """
-    array_eye = 0.6 * np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = 0.6 * np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
 
     num = 2 * np.array([6, 6, 6])
@@ -168,11 +168,11 @@ def test_dice_general():
     non binary features and checking
     against precomputed tensor.
     """
-    array_eye = 0.6 * np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = 0.6 * np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
 
     y_prod = np.sum(tensor_eye * tensor_pred, axis=(1, 2, 3))
@@ -191,11 +191,11 @@ def test_weighted_bce():
     Checking binary cross entropy calculation
     against a precomputed tensor.
     """
-    array_eye = np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
 
     expect = [1.535057, 1.535057, 1.535057]
@@ -210,7 +210,7 @@ def test_separable_filter_0():
     """
     pass
     # kernel = np.empty((0))
-    # array_eye = np.identity((3))
+    # array_eye = np.identity(3, dtype=np.float32)
     # get = label.separable_filter3d(array_eye, kernel)
     # expect = array_eye
     # assert assertTensorsEqual(get, expect)
@@ -223,8 +223,8 @@ def test_separable_filter_else():
     function.
     """
     k = np.ones((3, 3, 3, 3))
-    array_eye = np.identity((3))
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, :, 0, 0] = array_eye
 
     expect = np.ones((3, 3, 3, 3))
@@ -277,10 +277,10 @@ def test_squared_error():
     Testing squared error function by comparing
     to precomputed tensor.
     """
-    tensor_mask = np.zeros((3, 3, 3, 3))
+    tensor_mask = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_mask[0, 0, 0, 0] = 1
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, :, :, :] = 1
     expect = np.array([26 / 27, 1.0, 1.0])
     get = label.squared_error(tensor_mask, tensor_pred)
@@ -293,11 +293,11 @@ def test_single_scale_loss_dice():
     precomputed, known dice loss for given
     inputs.
     """
-    array_eye = np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
 
     num = 2 * np.array([6, 6, 6])
@@ -313,11 +313,11 @@ def test_single_scale_loss_bce():
     Testing bce single scale loss entry
     returns known loss tensor for given inputs.
     """
-    array_eye = np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
 
     expect = [1.535057, 1.535057, 1.535057]
@@ -332,11 +332,11 @@ def test_single_scale_loss_dg():
     scale loss function returns known loss
     tensor for given inputs.
     """
-    array_eye = 0.6 * np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = 0.6 * np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
 
     y_prod = np.sum(tensor_eye * tensor_pred, axis=(1, 2, 3))
@@ -354,11 +354,11 @@ def test_single_scale_loss_jacc():
     Testing single scale loss returns known loss
     tensor when called with jaccard argment.
     """
-    array_eye = np.identity((3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye[:, :, 0:3, 0:3] = array_eye
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, 0:2, :, :] = array_eye
     num = np.array([6, 6, 6])
     denom = np.array([9, 9, 9]) + np.array([6, 6, 6]) - num
@@ -374,7 +374,7 @@ def test_single_scale_loss_mean_sq():
     known mean sq value tensor when passed with
     mean squared arg,
     """
-    tensor_mask = np.zeros((3, 3, 3, 3))
+    tensor_mask = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_mask[0, 0, 0, 0] = 1
 
     tensor_pred = np.ones((3, 3, 3, 3))
@@ -389,9 +389,9 @@ def test_single_scale_loss_other():
     Test value error raised if non supported
     string passed to the single scale loss function.
     """
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
 
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
 
     with pytest.raises(ValueError):
         label.single_scale_loss(tensor_eye, tensor_pred, "random")
@@ -402,7 +402,7 @@ def test_multi_scale_loss_pred_len():
     Test assertion error raised if a wrongly sized tensor
     is passed to the multi-scale loss function.
     """
-    tensor_true = np.zeros((3, 3, 3, 3))
+    tensor_true = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred = np.zeros((3, 3, 3))
     with pytest.raises(AssertionError):
         label.multi_scale_loss(
@@ -416,7 +416,7 @@ def test_multi_scale_loss_true_len():
     is passed to the multi-scale loss function.
     """
     tensor_true = np.zeros((3, 3, 3))
-    tensor_pred = np.zeros((3, 3, 3, 3))
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     with pytest.raises(AssertionError):
         label.multi_scale_loss(
             tensor_true, tensor_pred, loss_type="jaccard", loss_scales=[0, 1, 2]
@@ -428,10 +428,10 @@ def test_multi_scale_loss_kernel():
     Test multi-scale loss kernel returns the appropriate
     loss tensor for same inputs and jaccard cal.
     """
-    loss_values = np.asarray([1, 2, 3])
-    array_eye = np.identity((3))
-    tensor_pred = np.zeros((3, 3, 3, 3))
-    tensor_eye = np.zeros((3, 3, 3, 3))
+    loss_values = np.asarray([1, 2, 3], dtype=np.float32)
+    array_eye = np.identity(3, dtype=np.float32)
+    tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
+    tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
 
     tensor_eye[:, :, 0:3, 0:3] = array_eye
     tensor_pred[:, :, 0, 0] = array_eye
@@ -447,7 +447,7 @@ def test_multi_scale_loss_kernel():
             for s in loss_values
         ]
     )
-    expect = np.mean(list_losses, axis=0)
+    expect = tf.convert_to_tensor(np.mean(list_losses, axis=0), dtype=tf.float32)
     get = label.multi_scale_loss(tensor_eye, tensor_pred, "jaccard", loss_values)
     assert assertTensorsEqual(get, expect)
 

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -21,6 +21,8 @@ def assertTensorsEqual(x, y):
     :param y:
     :return:
     """
+    x = tf.cast(x, dtype=tf.float32)
+    y = tf.cast(y, dtype=tf.float32)
     return tf.reduce_max(tf.abs(x - y)).numpy() < 1e-6
 
 

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -236,13 +236,14 @@ def test_separable_filter_else():
     zero length tensor is passed to the
     function.
     """
-    k = np.ones((3, 3, 3, 3))
+    k = np.ones((3, 3, 3, 3), dtype=np.float32)
     array_eye = np.identity(3, dtype=np.float32)
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_pred[:, :, 0, 0] = array_eye
     tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
+    k = tf.convert_to_tensor(k, dtype=tf.float32)
 
-    expect = np.ones((3, 3, 3, 3))
+    expect = np.ones((3, 3, 3, 3), dtype=np.float32)
     expect = tf.convert_to_tensor(expect, dtype=tf.float32)
 
     get = label.separable_filter3d(tensor_pred, k)

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -407,7 +407,7 @@ def test_single_scale_loss_mean_sq():
     tensor_mask[0, 0, 0, 0] = 1
     tensor_mask = tf.convert_to_tensor(tensor_mask, dtype=tf.float32)
 
-    tensor_pred = tf.convert_to_tensor(np.zeros((3, 3, 3, 3)), dtype=tf.float32)
+    tensor_pred = tf.convert_to_tensor(np.ones((3, 3, 3, 3)), dtype=tf.float32)
     expect = tf.convert_to_tensor(np.array([26 / 27, 1.0, 1.0]), dtype=tf.float32)
 
     get = label.single_scale_loss(tensor_mask, tensor_pred, "mean-squared")

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -403,8 +403,9 @@ def test_single_scale_loss_mean_sq():
     known mean sq value tensor when passed with
     mean squared arg,
     """
-    tensor_mask = tf.convert_to_tensor(np.zeros((3, 3, 3, 3)), dtype=tf.float32)
+    tensor_mask = np.zeros((3, 3, 3, 3))
     tensor_mask[0, 0, 0, 0] = 1
+    tensor_mask = tf.convert_to_tensor(tensor_mask, dtype=tf.float32)
 
     tensor_pred = tf.convert_to_tensor(np.zeros((3, 3, 3, 3)), dtype=tf.float32)
     expect = tf.convert_to_tensor(np.array([26 / 27, 1.0, 1.0]), dtype=tf.float32)

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -457,7 +457,7 @@ def test_multi_scale_loss_kernel():
     Test multi-scale loss kernel returns the appropriate
     loss tensor for same inputs and jaccard cal.
     """
-    loss_values = np.asarray([1, 2, 3], dtype=np.float32)
+    loss_values = [1, 2, 3]
     array_eye = np.identity(3, dtype=np.float32)
     tensor_pred = np.zeros((3, 3, 3, 3), dtype=np.float32)
     tensor_eye = np.zeros((3, 3, 3, 3), dtype=np.float32)
@@ -466,17 +466,7 @@ def test_multi_scale_loss_kernel():
     tensor_pred[:, :, 0, 0] = array_eye
     tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
     tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
-    list_losses = np.array(
-        [
-            label.single_scale_loss(
-                y_true=label.separable_filter3d(tensor_eye, label.gauss_kernel1d(s)),
-                y_pred=label.separable_filter3d(tensor_pred, label.gauss_kernel1d(s)),
-                loss_type="jaccard",
-            )
-            for s in loss_values
-        ]
-    )
-    expect = tf.convert_to_tensor(np.mean(list_losses, axis=0), dtype=tf.float32)
+    expect = tf.constant([0.9938445, 0.9924956, 0.9938445], dtype=tf.float32)
     get = label.multi_scale_loss(tensor_eye, tensor_pred, "jaccard", loss_values)
     assert assertTensorsEqual(get, expect)
 

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -40,10 +40,10 @@ def test_gauss_kernel1d_else():
     expect a tensor returned.
     """
     sigma = 3
-    get = tf.cast(label.gauss_kernel1d(sigma), dtype=tf.float64)
+    get = tf.cast(label.gauss_kernel1d(sigma), dtype=tf.float32)
     list_vals = range(-sigma * 3, sigma * 3 + 1)
     exp = [np.exp(-0.5 * x ** 2 / sigma ** 2) for x in list_vals]
-    expect = tf.convert_to_tensor(exp, dtype=tf.float64)
+    expect = tf.convert_to_tensor(exp, dtype=tf.float32)
     expect = expect / tf.reduce_sum(expect)
     assert assertTensorsEqual(get, expect)
 
@@ -64,10 +64,10 @@ def test_cauchy_kernel_else():
     tensor returned.
     """
     sigma = 3
-    get = tf.cast(label.cauchy_kernel1d(sigma), dtype=tf.float64)
+    get = tf.cast(label.cauchy_kernel1d(sigma), dtype=tf.float32)
     list_vals = range(-sigma * 5, sigma * 5 + 1)
     exp = [1 / ((x / sigma) ** 2 + 1) for x in list_vals]
-    expect = tf.convert_to_tensor(exp, dtype=tf.float64)
+    expect = tf.convert_to_tensor(exp, dtype=tf.float32)
     expect = expect / tf.reduce_sum(expect)
     assert assertTensorsEqual(get, expect)
 
@@ -435,8 +435,8 @@ def test_multi_scale_loss_kernel():
 
     tensor_eye[:, :, 0:3, 0:3] = array_eye
     tensor_pred[:, :, 0, 0] = array_eye
-    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.double)
-    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.double)
+    tensor_eye = tf.convert_to_tensor(tensor_eye, dtype=tf.float32)
+    tensor_pred = tf.convert_to_tensor(tensor_pred, dtype=tf.float32)
     list_losses = np.array(
         [
             label.single_scale_loss(


### PR DESCRIPTION
# Description

Case constants to tf.float32 to make sure using GPU `pytest test/units` can pass.

Fixes #188

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

On PT with GPU and locally without GPU.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
