### PR TITLE
Issue #169 [ci skip] doc links fixed

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -1,2 +1,2 @@
 Find out more about
-[DeepReg Demos](https://ucl-candi.github.io/DeepReg/#/tutorial_demo).
+[DeepReg Demos](https://DeepRegNet.github.io/DeepReg/#/tutorial_demo).

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -55,11 +55,11 @@ offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to
-the community leaders responsible for enforcement at deepreg@outlook.com. All complaints
-will be reviewed and investigated promptly and fairly - community leaders will aim for a
-first response to complaints under 48h. The community leaders will aim to respond within
-one week to the person who filed the report with either a resolution or an explanation
-as to why the situation has not been resolved.
+the community leaders responsible for enforcement at DeepRegNet@gmail.com. All
+complaints will be reviewed and investigated promptly and fairly - community leaders
+will aim for a first response to complaints under 48h. The community leaders will aim to
+respond within one week to the person who filed the report with either a resolution or
+an explanation as to why the situation has not been resolved.
 
 All community leaders are obligated to respect the privacy and security of the reporter
 of any incident.
@@ -68,7 +68,7 @@ of any incident.
 should the reporter not feel comfortable sharing the report with such member, reports
 can be made privately to any of the members of the community leaders by contacting them
 privately. Contact methods are listed at
-https://github.com/ucl-candi/DeepReg/wiki/Contact. The enforcement process will be
+https://github.com/DeepRegNet/DeepReg/wiki/Contact. The enforcement process will be
 followed, but will exclude the member or members that the report concerns from
 discussion and decision making.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We welcome contributions to DeepReg.
 
 ## Reporting bugs and feature requests
 
-Please create a new issue on: https://github.com/ucl-candi/DeepReg/issues/new
+Please create a new issue on: https://github.com/DeepRegNet/DeepReg/issues/new
 
 When reporting a bug, please include:
 
@@ -16,11 +16,11 @@ When reporting a bug, please include:
 
 The easiest way to contribute is to follow these guidelines:
 
-1. Look through the issues on https://github.com/ucl-candi/DeepReg/issues and assign the
-   relevant issue to yourself. If there is not an existing issue that covers your work,
-   please create one: https://github.com/ucl-candi/DeepReg/issues/new
+1. Look through the issues on https://github.com/DeepRegNet/DeepReg/issues and assign
+   the relevant issue to yourself. If there is not an existing issue that covers your
+   work, please create one: https://github.com/DeepRegNet/DeepReg/issues/new
 2. Read the design considerations below.
-3. Fork the repository: https://github.com/ucl-candi/DeepReg/forks/new
+3. Fork the repository: https://github.com/DeepRegNet/DeepReg/forks/new
 4. Create a branch for your changes. The branch name should start with the issue number,
    followed by hyphen separated words describing the issue. For example:
    1-update-contribution-guidelines
@@ -29,7 +29,7 @@ The easiest way to contribute is to follow these guidelines:
    `Issue #<issue number>`, for example: "Issue #1: Fixed typo". Commit in small,
    related chunks. Review each commit and explain its purpose in the commit message.
    Refer to the commit style section below for a more detailed guide.
-7. Submit a merge request: https://github.com/ucl-candi/DeepReg/merge-requests/new
+7. Submit a merge request: https://github.com/DeepRegNet/DeepReg/merge-requests/new
 8. Merge request will be reviewed and, if necessary, changes suggested before merge to
    master.
 
@@ -122,35 +122,34 @@ an workaround, please update this section. Otherwise, please raise an issue.
 
 ## Documentation Pages
 
-Below are instructions for creating and modifying pages on this website, as found
- within the `docs` folder of the repository.
+Below are instructions for creating and modifying pages on this website, as found within
+the `docs` folder of the repository.
 
 ### Linux
 
 - [Docsify](https://docsify.js.org/) converts markdown files into pages and they are
-hosted on github page. 
-- Use `cd docs && python -m http.server` to visualize the pages
-locally.
+  hosted on github page.
+- Use `cd docs && python -m http.server` to visualize the pages locally.
 - The required package
-[simple_http_server](https://github.com/keijack/python-simple-http-server) has been
-installed during the package installation via `pip install -e .`.
+  [simple_http_server](https://github.com/keijack/python-simple-http-server) has been
+  installed during the package installation via `pip install -e .`.
 
 ### Windows
 
 - Install [Jekyll](https://jekyllrb.com/docs/installation/windows/) via RubyInstaller,
- and follow the install instructions on that page.
-- In a Windows Command Prompt (WCP) started with Ruby, use `gem install github-pages`
- to install the required packages.
+  and follow the install instructions on that page.
+- In a Windows Command Prompt (WCP) started with Ruby, use `gem install github-pages` to
+  install the required packages.
 - Next, the same WCP - navigate to the `docs` folder in DeepReg, and use `jekyll serve`
- to create a directory located at `../docs/_site`. 
-  - You should now see a local version of the site at http://127.0.0.1:4000. 
+  to create a directory located at `../docs/_site`.
+  - You should now see a local version of the site at http://127.0.0.1:4000.
   - You will need to work in the newly created `../docs/_site` folder to make your
-   changes, and copy them back to `../docs` in order to commit them here.
+    changes, and copy them back to `../docs` in order to commit them here.
 
-_Note:_ Make sure to frequently update the GitHub pages gem with 
+_Note:_ Make sure to frequently update the GitHub pages gem with
 `gem update github-pages`. There are dependencies and various packages that are updated
- frequently - and the website may not display locally the same as it will when pushed
-  if you do not have the most recent versions.
+frequently - and the website may not display locally the same as it will when pushed if
+you do not have the most recent versions.
 
 ### MacOS
 

--- a/docs/_coverpage.md
+++ b/docs/_coverpage.md
@@ -6,4 +6,4 @@
 
 - TensorFlow 2 based.
 
-[GitHub](https://github.com/ucl-candi/DeepReg/) [Get Started](quick_start.md)
+[GitHub](https://github.com/DeepRegNet/DeepReg/) [Get Started](quick_start.md)

--- a/docs/doc_configuration.md
+++ b/docs/doc_configuration.md
@@ -73,5 +73,5 @@ The `dataset` section defines the dataset and corresponding loader. Read the
 
 The `train` section defines the neural network, training loss and other training
 hyper-parameters, such as batch size, optimizer, and learning rate. Read the
-[example configuration](https://github.com/ucl-candi/DeepReg/blob/master/deepreg/config/unpaired_labeled_ddf.yaml)
+[example configuration](https://github.com/DeepRegNet/DeepReg/blob/master/deepreg/config/unpaired_labeled_ddf.yaml)
 for more details.

--- a/docs/doc_data_loader.md
+++ b/docs/doc_data_loader.md
@@ -182,7 +182,7 @@ File names should be consistent between top directories, e.g.:
   - ...
 
 Check
-[test paired data](https://github.com/ucl-candi/DeepReg/tree/master/data/test/nifti/paired)
+[test paired data](https://github.com/DeepRegNet/DeepReg/tree/master/data/test/nifti/paired)
 as an example.
 
 Optionally, the data may not be all saved directly under the top directory. They can be
@@ -217,7 +217,7 @@ The keys should be consistent between files, e.g.:
   - ...
 
 Check
-[test paired data](https://github.com/ucl-candi/DeepReg/tree/master/data/test/h5/paired)
+[test paired data](https://github.com/DeepRegNet/DeepReg/tree/master/data/test/h5/paired)
 as an example.
 
 ## Unpaired images
@@ -299,7 +299,7 @@ File names should be consistent between top directories, e.g.:
   - ...
 
 Check
-[test unpaired data](https://github.com/ucl-candi/DeepReg/tree/master/data/test/nifti/unpaired)
+[test unpaired data](https://github.com/DeepRegNet/DeepReg/tree/master/data/test/nifti/unpaired)
 as an example.
 
 #### H5
@@ -323,7 +323,7 @@ The keys should be consistent between files, e.g.:
   - ...
 
 Check
-[test unpaired data](https://github.com/ucl-candi/DeepReg/tree/master/data/test/h5/unpaired)
+[test unpaired data](https://github.com/DeepRegNet/DeepReg/tree/master/data/test/h5/unpaired)
 as an example.
 
 ## Grouped images
@@ -470,7 +470,7 @@ consistent between top directories, e.g.:
   - ...
 
 Check
-[test unpaired data](https://github.com/ucl-candi/DeepReg/tree/master/data/test/nifti/grouped)
+[test unpaired data](https://github.com/DeepRegNet/DeepReg/tree/master/data/test/nifti/grouped)
 as an example.
 
 #### H5
@@ -503,5 +503,5 @@ The keys should be consistent between files, e.g.:
   - ...
 
 Check
-[test unpaired data](https://github.com/ucl-candi/DeepReg/tree/master/data/test/h5/grouped)
+[test unpaired data](https://github.com/DeepRegNet/DeepReg/tree/master/data/test/h5/grouped)
 as an example.

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
     <script>
       window.$docsify = {
         name: "DeepReg",
-        nameLink: "https://ucl-candi.github.io/DeepReg/",
+        nameLink: "https://DeepRegNet.github.io/DeepReg/",
         coverpage: true,
         onlyCover: false,
         homepage: "quick_start.md",
@@ -21,7 +21,7 @@
         loadSidebar: true, // load from _sidebar.md
         relativePath: false,
         subMaxLevel: 3,
-        repo: "https://github.com/ucl-candi/DeepReg/",
+        repo: "https://github.com/DeepRegNet/DeepReg/",
         search: "auto",
         tabs: {
           persist: true, // default

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -71,16 +71,16 @@ The recommended method is to clone the repository and install it locally. All ne
 dependencies will be installed automatically.
 
 ```bash
-git clone https://github.com/ucl-candi/DeepReg.git # clone the repository
+git clone https://github.com/DeepRegNet/DeepReg.git # clone the repository
 pip install -e . # install the package
 ```
 
 Optionally, you can install the
-[master branch](https://github.com/ucl-candi/DeepReg.git) of the package directly from
+[master branch](https://github.com/DeepRegNet/DeepReg.git) of the package directly from
 the repository:
 
 ```bash
-pip install git+https://github.com/ucl-candi/DeepReg.git
+pip install git+https://github.com/DeepRegNet/DeepReg.git
 ```
 
 ## Train

--- a/docs/tutorial_demo.md
+++ b/docs/tutorial_demo.md
@@ -25,15 +25,21 @@ This tutorial describe several examples in the `DeepReg Demos` to explain how th
 different scenarios can be implemented with `DeepReg`. A complete list of demos can be
 found in the [DeepReg Demos Index](#deepreg-demos-index)
 
-## paired_ct_lung
+## Registering paired CT lung images
+
+[paired_ct_lung](./paired_ct_lung)
 
 (under development)
 
-## unpaired_ct_lung
+## Registering unpaired CT lung images
+
+[unpaired_ct_lung](./unpaired_ct_lung)
 
 (under development)
 
 ## DeepReg Demos Index
+
+A complete list of demos is provided below.
 
 ### [paired_ct_lung](./paired_ct_lung)
 


### PR DESCRIPTION
# Description

Links are fixed to NiftyRegNet-based, though the redirecting still works.


Fixes #169 

## Type of change
do update