### PR TITLE
Issue #55: Improve coverage for layer_utils.py

### DIFF
--- a/deepreg/model/layer_util.py
+++ b/deepreg/model/layer_util.py
@@ -466,10 +466,6 @@ def resize3d(
         has_channel = False
         has_batch = False
         input_image_shape = image.shape[0:3]
-    else:
-        raise ValueError(
-            f"Unknown image_dim in resize3d. It should be 3 or 4 or 5, got {image_dim}"
-        )
 
     # no need of resize
     if input_image_shape == tuple(size):


### PR DESCRIPTION
Reached 100% coverage for layer_utils.py and removed unreachable code block where a secondary check of image_dim took place.

# Description

Previous test_layer_utils achieved ~95% coverage - this covers all failure cases for the functions which were not previously covered.

Fixes #55 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested coverage with `pytest test_layer_utils.py --cov-report term-missing --cov` achieves 100%

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
