### PR TITLE
unpaired data config should only use `image_shape` [skip ci]

### DIFF
--- a/demos/unpaired_ct_lung/unpaired_ct_lung.yaml
+++ b/demos/unpaired_ct_lung/unpaired_ct_lung.yaml
@@ -6,5 +6,4 @@ dataset:
   format: "nifti"
   type: "unpaired" # paired / unpaired / grouped
   labeled: true
-  moving_image_shape: [192, 192, 208]
-  fixed_image_shape: [192, 192, 208]
+  image_shape: [192, 192, 208]


### PR DESCRIPTION
# Description

Fix the demo config in case of unpaired, as shown here https://deepregnet.github.io/DeepReg/#/doc_data_loader?id=configuration-1, we should use `image_shape` instead of `moving_image_shape` or `fixed_image_shape` as images are not paired.
