### PR TITLE
Issue #230: add support for nii files

### DIFF
--- a/deepreg/dataset/loader/nifti_loader.py
+++ b/deepreg/dataset/loader/nifti_loader.py
@@ -17,6 +17,10 @@ class NiftiFileLoader(FileLoader):
         self.file_paths = get_sorted_filenames_in_dir(
             dir_path=os.path.join(dir_path, name), suffix="nii.gz"
         )
+        self.file_paths = self.file_paths + get_sorted_filenames_in_dir(
+            dir_path=os.path.join(dir_path, name), suffix="nii"
+        )
+        self.file_paths = sorted(self.file_paths)
         self.set_group_structure()
 
     def get_data(self, index: (int, tuple)):


### PR DESCRIPTION
# Description

Added support for nii files in the nifti loader. The nifti loader can now handle folders with the following cases:
  - All nii.gz files
  - All nii files
  - Some nii and some nii.gz files

Fixes #230 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

ran unit tests for nifti_loader locally and tested nifti loader with demo data from mr_us_brain demo data which has nii files.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
