### PR TITLE
Revert "Issue #230: add support for nii files"

### DIFF
--- a/deepreg/dataset/loader/nifti_loader.py
+++ b/deepreg/dataset/loader/nifti_loader.py
@@ -17,10 +17,6 @@ class NiftiFileLoader(FileLoader):
         self.file_paths = get_sorted_filenames_in_dir(
             dir_path=os.path.join(dir_path, name), suffix="nii.gz"
         )
-        self.file_paths = self.file_paths + get_sorted_filenames_in_dir(
-            dir_path=os.path.join(dir_path, name), suffix="nii"
-        )
-        self.file_paths = sorted(self.file_paths)
         self.set_group_structure()
 
     def get_data(self, index: (int, tuple)):


### PR DESCRIPTION
Reverts DeepRegNet/DeepReg#237

I suggest to revert this PR and do it properly.

We need to
- allow image or label to have suffix either `nii` or `nii.gz`, and their ID do not depend on the suffix
- add test to test these cases

The changes can be
- in `get_sorted_filenames_in_dir`, we will allow a list of suffixes, also rename the func as `get_sorted_filenames_in_dir_with_suffix`
- change `get_data_ids` to make it independent of the file type

To validate the fix,
we need some test data and corresponding tests