### PR TITLE
simplify error message check in tests

### DIFF
--- a/deepreg/model/layer.py
+++ b/deepreg/model/layer.py
@@ -524,8 +524,6 @@ class LocalNetResidual3dBlock(tf.keras.layers.Layer):
         self._act = Activation()
 
     def call(self, inputs, training=None, **kwargs):
-        layer_util.check_inputs(inputs, 2, "ResidualBlock")
-
         return self._act(
             self._norm(inputs=self._conv3d(inputs=inputs[0]), training=training)
             + inputs[1]
@@ -555,7 +553,6 @@ class LocalNetUpSampleResnetBlock(tf.keras.layers.Layer):
         :return: None
         """
         super(LocalNetUpSampleResnetBlock, self).build(input_shape)
-        layer_util.check_inputs(input_shape, 2, "UpSampleResnetBlock build")
 
         output_shape = input_shape[1][1:4]
         self._deconv3d_block = Deconv3dBlock(
@@ -571,8 +568,6 @@ class LocalNetUpSampleResnetBlock(tf.keras.layers.Layer):
         :param kwargs:
         :return:
         """
-        layer_util.check_inputs(inputs, 2, "UpSampleResnetBlock call")
-
         inputs_nonskip, inputs_skip = inputs[0], inputs[1]
         h0 = self._deconv3d_block(inputs=inputs_nonskip, training=training)
         if self._use_additive_upsampling:

--- a/deepreg/model/layer_util.py
+++ b/deepreg/model/layer_util.py
@@ -7,26 +7,6 @@ import numpy as np
 import tensorflow as tf
 
 
-def check_inputs(inputs, size, msg=""):
-    """
-    Function to assert correct input types and length
-    :param inputs: list or tuple
-    :param size: int, defines corect size of input tuple/list
-    :param msg: string type to return with raised ValueError
-    """
-    if msg != "":
-        msg += " "
-    if not isinstance(inputs, (list, tuple)):
-        raise ValueError(msg + "Inputs should be a list or tuple")
-    if len(inputs) != size:
-        raise ValueError(
-            msg
-            + """Inputs should be a list or tuple\
-                     of size %d, but received %d"""
-            % (size, len(inputs))
-        )
-
-
 def get_reference_grid(grid_size: (tuple, list)) -> tf.Tensor:
     """
     :param grid_size: list or tuple of size 3, [dim1, dim2, dim3]
@@ -163,11 +143,10 @@ def pyramid_combination(values: list, weights: list) -> tf.Tensor:
     """
     if len(values[0].shape) != len(weights[0].shape):
         raise ValueError(
-            """In pyramid_combination, elements of values and
-            weights should have same dimension.
-            value shape = {}, weight = {}""".format(
-                values[0].shape, weights[0].shape
-            )
+            f"In pyramid_combination, "
+            f"elements of values and weights should have same dimension. "
+            f"value shape = {values[0].shape}, "
+            f"weight = {weights[0].shape}"
         )
     if 2 ** len(weights) != len(values):
         raise ValueError(

--- a/test/unit/test_dataset_load.py
+++ b/test/unit/test_dataset_load.py
@@ -76,23 +76,20 @@ def test_get_data_loader():
     config["dataset"]["dir"]["train"] += ".h5"
     with pytest.raises(ValueError) as exec_info:
         load.get_data_loader(data_config=config["dataset"], mode="train")
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "is not a directory or does not exist" in msg
+    assert "is not a directory or does not exist" in str(exec_info.value)
 
     # check directory not existed error
     config = load_yaml("deepreg/config/test/paired_nifti.yaml")
     config["dataset"]["dir"]["train"] = "/this_should_not_existed"
     with pytest.raises(ValueError) as exec_info:
         load.get_data_loader(data_config=config["dataset"], mode="train")
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "is not a directory or does not exist" in msg
+    assert "is not a directory or does not exist" in str(exec_info.value)
 
     # check mode
     config = load_yaml("deepreg/config/test/paired_nifti.yaml")
     with pytest.raises(AssertionError) as exec_info:
         load.get_data_loader(data_config=config["dataset"], mode="example")
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "mode must be one of train/valid/test" in msg
+    assert "mode must be one of train/valid/test" in str(exec_info.value)
 
 
 def test_get_single_data_loader():
@@ -143,8 +140,7 @@ def test_get_single_data_loader():
             common_args=common_args,
             data_dir_path=config["dataset"]["dir"]["train"],
         )
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Unknown data format" in msg
+    assert "Unknown data format" in str(exec_info.value)
 
     # wrong keys for paired loader
     config = load_yaml("deepreg/config/test/paired_nifti.yaml")
@@ -158,8 +154,9 @@ def test_get_single_data_loader():
             common_args=common_args,
             data_dir_path=config["dataset"]["dir"]["train"],
         )
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Paired Loader requires 'moving_image_shape' and 'fixed_image_shape'" in msg
+    assert "Paired Loader requires 'moving_image_shape' and 'fixed_image_shape'" in str(
+        exec_info.value
+    )
 
     # wrong keys for unpaired loader
     config = load_yaml("deepreg/config/test/unpaired_nifti.yaml")
@@ -172,8 +169,7 @@ def test_get_single_data_loader():
             common_args=common_args,
             data_dir_path=config["dataset"]["dir"]["train"],
         )
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Unpaired Loader requires 'image_shape'" in msg
+    assert "Unpaired Loader requires 'image_shape'" in str(exec_info.value)
 
     # wrong keys for grouped loader
     config = load_yaml("deepreg/config/test/unpaired_nifti.yaml")
@@ -186,5 +182,4 @@ def test_get_single_data_loader():
             common_args=common_args,
             data_dir_path=config["dataset"]["dir"]["train"],
         )
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Grouped Loader requires 'image_shape'" in msg
+    assert "Grouped Loader requires 'image_shape'" in str(exec_info.value)

--- a/test/unit/test_dataset_load.py
+++ b/test/unit/test_dataset_load.py
@@ -74,22 +74,22 @@ def test_get_data_loader():
     # check not a directory error
     config = load_yaml("deepreg/config/test/paired_nifti.yaml")
     config["dataset"]["dir"]["train"] += ".h5"
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         load.get_data_loader(data_config=config["dataset"], mode="train")
-    assert "is not a directory or does not exist" in str(exec_info.value)
+    assert "is not a directory or does not exist" in str(err_info.value)
 
     # check directory not existed error
     config = load_yaml("deepreg/config/test/paired_nifti.yaml")
     config["dataset"]["dir"]["train"] = "/this_should_not_existed"
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         load.get_data_loader(data_config=config["dataset"], mode="train")
-    assert "is not a directory or does not exist" in str(exec_info.value)
+    assert "is not a directory or does not exist" in str(err_info.value)
 
     # check mode
     config = load_yaml("deepreg/config/test/paired_nifti.yaml")
-    with pytest.raises(AssertionError) as exec_info:
+    with pytest.raises(AssertionError) as err_info:
         load.get_data_loader(data_config=config["dataset"], mode="example")
-    assert "mode must be one of train/valid/test" in str(exec_info.value)
+    assert "mode must be one of train/valid/test" in str(err_info.value)
 
 
 def test_get_single_data_loader():
@@ -133,21 +133,21 @@ def test_get_single_data_loader():
 
     # not supported data loader
     config = load_yaml("deepreg/config/test/paired_nifti.yaml")
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         load.get_single_data_loader(
             data_type="NotSupported",
             data_config=config["dataset"],
             common_args=common_args,
             data_dir_path=config["dataset"]["dir"]["train"],
         )
-    assert "Unknown data format" in str(exec_info.value)
+    assert "Unknown data format" in str(err_info.value)
 
     # wrong keys for paired loader
     config = load_yaml("deepreg/config/test/paired_nifti.yaml")
     # delete correct keys and add wrong one
     config["dataset"].pop("moving_image_shape", None)
     config["dataset"].pop("fixed_image_shape", None)
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         load.get_single_data_loader(
             data_type="paired",
             data_config=config["dataset"],
@@ -155,31 +155,31 @@ def test_get_single_data_loader():
             data_dir_path=config["dataset"]["dir"]["train"],
         )
     assert "Paired Loader requires 'moving_image_shape' and 'fixed_image_shape'" in str(
-        exec_info.value
+        err_info.value
     )
 
     # wrong keys for unpaired loader
     config = load_yaml("deepreg/config/test/unpaired_nifti.yaml")
     # delete correct keys and add wrong one
     config["dataset"].pop("image_shape", None)
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         load.get_single_data_loader(
             data_type="unpaired",
             data_config=config["dataset"],
             common_args=common_args,
             data_dir_path=config["dataset"]["dir"]["train"],
         )
-    assert "Unpaired Loader requires 'image_shape'" in str(exec_info.value)
+    assert "Unpaired Loader requires 'image_shape'" in str(err_info.value)
 
     # wrong keys for grouped loader
     config = load_yaml("deepreg/config/test/unpaired_nifti.yaml")
     # delete correct keys and add wrong one
     config["dataset"].pop("intra_group_prob", None)
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         load.get_single_data_loader(
             data_type="grouped",
             data_config=config["dataset"],
             common_args=common_args,
             data_dir_path=config["dataset"]["dir"]["train"],
         )
-    assert "Grouped Loader requires 'image_shape'" in str(exec_info.value)
+    assert "Grouped Loader requires 'image_shape'" in str(err_info.value)

--- a/test/unit/test_h5_loader.py
+++ b/test/unit/test_h5_loader.py
@@ -78,8 +78,7 @@ def test_set_group_structure_ungrouped():
     loader.set_group_structure()
     with pytest.raises(AttributeError) as exec_info:
         loader.group_ids
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "object has no attribute" in msg
+    assert "object has no attribute" in str(exec_info.value)
 
 
 def test_get_data_ids():
@@ -204,8 +203,7 @@ def test_init_incompatible_conditions():
     name = "fixed_images"
     with pytest.raises(IndexError) as exec_info:
         H5FileLoader(dir_path=dir_path, name=name, grouped=True)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "index out of range" in msg
+    assert "index out of range" in str(exec_info.value)
 
 
 def test_get_data_incompatible_args():
@@ -234,5 +232,4 @@ def test_get_data_incorrect_args():
     index = "abc"
     with pytest.raises(ValueError) as exec_info:
         loader.get_data(index)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "must be int, or tuple" in msg
+    assert "must be int, or tuple" in str(exec_info.value)

--- a/test/unit/test_h5_loader.py
+++ b/test/unit/test_h5_loader.py
@@ -76,9 +76,9 @@ def test_set_group_structure_ungrouped():
 
     loader = H5FileLoader(dir_path=dir_path, name=name, grouped=False)
     loader.set_group_structure()
-    with pytest.raises(AttributeError) as exec_info:
+    with pytest.raises(AttributeError) as err_info:
         loader.group_ids
-    assert "object has no attribute" in str(exec_info.value)
+    assert "object has no attribute" in str(err_info.value)
 
 
 def test_get_data_ids():
@@ -201,9 +201,9 @@ def test_init_incompatible_conditions():
     """
     dir_path = "./data/test/h5/paired/test"
     name = "fixed_images"
-    with pytest.raises(IndexError) as exec_info:
+    with pytest.raises(IndexError) as err_info:
         H5FileLoader(dir_path=dir_path, name=name, grouped=True)
-    assert "index out of range" in str(exec_info.value)
+    assert "index out of range" in str(err_info.value)
 
 
 def test_get_data_incompatible_args():
@@ -230,6 +230,6 @@ def test_get_data_incorrect_args():
 
     loader = H5FileLoader(dir_path=dir_path, name=name, grouped=False)
     index = "abc"
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         loader.get_data(index)
-    assert "must be int, or tuple" in str(exec_info.value)
+    assert "must be int, or tuple" in str(err_info.value)

--- a/test/unit/test_layer_util.py
+++ b/test/unit/test_layer_util.py
@@ -86,21 +86,21 @@ def test_pyramid_combinations():
     # Check input lengths match - Fail
     weights = tf.constant(np.array([[[0.2]], [[0.2]]], dtype=np.float32))
     values = tf.constant(np.array([[1], [2]], dtype=np.float32))
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         layer_util.pyramid_combination(values=values, weights=weights)
     assert (
         "In pyramid_combination, elements of values and weights should have same dimension"
-        in str(exec_info.value)
+        in str(err_info.value)
     )
 
     # Check input lengths match - Fail
     weights = tf.constant(np.array([[0.2]], dtype=np.float32))
     values = tf.constant(np.array([[1]], dtype=np.float32))
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         layer_util.pyramid_combination(values=values, weights=weights)
     assert (
         "In pyramid_combination, num_dim = len(weights), len(values) must be 2 ** num_dim"
-        in str(exec_info.value)
+        in str(err_info.value)
     )
 
 
@@ -171,17 +171,17 @@ def test_resample():
     interpolation = "linear"
     vol = tf.constant(np.array([[0]], dtype=np.float32))  # shape = [1,1]
     loc = tf.constant(np.array([[0, 0], [0, 0]], dtype=np.float32))  # shape = [2,2]
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         layer_util.resample(vol=vol, loc=loc, interpolation=interpolation)
-    assert "vol shape inconsistent with loc" in str(exec_info.value)
+    assert "vol shape inconsistent with loc" in str(err_info.value)
 
     # Non-'linear' resampling - Fail
     interpolation = "some-string"
     vol = tf.constant(np.array([[0]], dtype=np.float32))  # shape = [1,1]
     loc = tf.constant(np.array([[0, 0], [0, 0]], dtype=np.float32))  # shape = [2,2]
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         layer_util.resample(vol=vol, loc=loc, interpolation=interpolation)
-    assert "resample supports only linear interpolation" in str(exec_info.value)
+    assert "resample supports only linear interpolation" in str(err_info.value)
 
 
 def test_random_transform_generator():
@@ -289,24 +289,22 @@ def test_warp_image_ddf():
 
     # wrong image shape
     wrong_image = tf.ones(moving_image_size, dtype="float32")
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         layer_util.warp_image_ddf(image=wrong_image, ddf=ddf, grid_ref=grid_ref)
-    assert "image shape must be (batch, m_dim1, m_dim2, m_dim3)" in str(exec_info.value)
+    assert "image shape must be (batch, m_dim1, m_dim2, m_dim3)" in str(err_info.value)
 
     # wrong ddf shape
     wrong_ddf = tf.ones((batch_size, *fixed_image_size, 2), dtype="float32")
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         layer_util.warp_image_ddf(image=image, ddf=wrong_ddf, grid_ref=grid_ref)
-    assert "ddf shape must be (batch, f_dim1, f_dim2, f_dim3, 3)" in str(
-        exec_info.value
-    )
+    assert "ddf shape must be (batch, f_dim1, f_dim2, f_dim3, 3)" in str(err_info.value)
 
     # wrong grid_ref shape
     wrong_grid_ref = tf.ones((batch_size, *moving_image_size, 3), dtype="float32")
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         layer_util.warp_image_ddf(image=image, ddf=ddf, grid_ref=wrong_grid_ref)
     assert "grid_ref shape must be (1, f_dim1, f_dim2, f_dim3, 3) or None" in str(
-        exec_info.value
+        err_info.value
     )
 
 
@@ -374,15 +372,15 @@ def test_resize3d():
     # Check resize3d for proper image dimensions - Fail
     input_shape = (1, 1)
     size = (1, 1, 1)
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         layer_util.resize3d(image=tf.ones(input_shape), size=size)
-    assert "resize3d takes input image of dimension 3 or 4 or 5" in str(exec_info.value)
+    assert "resize3d takes input image of dimension 3 or 4 or 5" in str(err_info.value)
 
     # Check resize3d for proper size - Fail
     input_shape = (1, 1, 1)
     size = (1, 1)
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         layer_util.resize3d(image=tf.ones(input_shape), size=size)
     assert "resize3d takes size of type tuple/list and of length 3" in str(
-        exec_info.value
+        err_info.value
     )

--- a/test/unit/test_layer_util.py
+++ b/test/unit/test_layer_util.py
@@ -11,70 +11,6 @@ import tensorflow as tf
 import deepreg.model.layer_util as layer_util
 
 
-def test_check_inputs():
-    """
-    Test check_inputs by confirming that it accepts proper
-    types and handles a few simple cases.
-    """
-    # Check inputs list - Pass
-    assert layer_util.check_inputs([], 0) is None
-
-    # Check inputs tuple - Pass
-    assert layer_util.check_inputs((), 0) is None
-
-    # Check inputs int - Fail
-    with pytest.raises(ValueError) as exec_info:
-        layer_util.check_inputs(0, 0)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Inputs should be a list or tuple" in msg
-
-    # Check inputs float - Fail
-    with pytest.raises(ValueError) as exec_info:
-        layer_util.check_inputs(0.0, 0)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Inputs should be a list or tuple" in msg
-
-    # Check size float - Fail
-    with pytest.raises(ValueError) as exec_info:
-        layer_util.check_inputs([1], 0.5)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Inputs should be a list or tuple of size" in msg
-
-    # Check size 0 - Pass
-    assert layer_util.check_inputs([], 0) is None
-    assert layer_util.check_inputs((), 0) is None
-
-    # Check size 0 - Fail
-    with pytest.raises(ValueError) as exec_info:
-        layer_util.check_inputs([0], 0)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Inputs should be a list or tuple of size" in msg
-    with pytest.raises(ValueError) as exec_info:
-        layer_util.check_inputs((0,), 0)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Inputs should be a list or tuple of size" in msg
-
-    # Check size 1 - Pass
-    assert layer_util.check_inputs([0], 1) is None
-    assert layer_util.check_inputs((0,), 1) is None
-
-    # Check size 1 - Fail
-    with pytest.raises(ValueError) as exec_info:
-        layer_util.check_inputs([], 1)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Inputs should be a list or tuple of size" in msg
-    with pytest.raises(ValueError) as exec_info:
-        layer_util.check_inputs((), 1)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Inputs should be a list or tuple of size" in msg
-
-    # Check msg spacing - Pass
-    with pytest.raises(ValueError) as exec_info:
-        layer_util.check_inputs(0, 0, msg="Start of message")
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Start of message" in msg
-
-
 def test_get_reference_grid():
     """
     Test get_reference_grid by confirming that it generates
@@ -152,10 +88,9 @@ def test_pyramid_combinations():
     values = tf.constant(np.array([[1], [2]], dtype=np.float32))
     with pytest.raises(ValueError) as exec_info:
         layer_util.pyramid_combination(values=values, weights=weights)
-    msg = " ".join(exec_info.value.args[0].split())
     assert (
         "In pyramid_combination, elements of values and weights should have same dimension"
-        in msg
+        in str(exec_info.value)
     )
 
     # Check input lengths match - Fail
@@ -163,10 +98,9 @@ def test_pyramid_combinations():
     values = tf.constant(np.array([[1]], dtype=np.float32))
     with pytest.raises(ValueError) as exec_info:
         layer_util.pyramid_combination(values=values, weights=weights)
-    msg = " ".join(exec_info.value.args[0].split())
     assert (
         "In pyramid_combination, num_dim = len(weights), len(values) must be 2 ** num_dim"
-        in msg
+        in str(exec_info.value)
     )
 
 
@@ -239,8 +173,7 @@ def test_resample():
     loc = tf.constant(np.array([[0, 0], [0, 0]], dtype=np.float32))  # shape = [2,2]
     with pytest.raises(ValueError) as exec_info:
         layer_util.resample(vol=vol, loc=loc, interpolation=interpolation)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "vol shape inconsistent with loc" in msg
+    assert "vol shape inconsistent with loc" in str(exec_info.value)
 
     # Non-'linear' resampling - Fail
     interpolation = "some-string"
@@ -248,8 +181,7 @@ def test_resample():
     loc = tf.constant(np.array([[0, 0], [0, 0]], dtype=np.float32))  # shape = [2,2]
     with pytest.raises(ValueError) as exec_info:
         layer_util.resample(vol=vol, loc=loc, interpolation=interpolation)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "resample supports only linear interpolation" in msg
+    assert "resample supports only linear interpolation" in str(exec_info.value)
 
 
 def test_random_transform_generator():
@@ -359,22 +291,23 @@ def test_warp_image_ddf():
     wrong_image = tf.ones(moving_image_size, dtype="float32")
     with pytest.raises(ValueError) as exec_info:
         layer_util.warp_image_ddf(image=wrong_image, ddf=ddf, grid_ref=grid_ref)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "image shape must be (batch, m_dim1, m_dim2, m_dim3)" in msg
+    assert "image shape must be (batch, m_dim1, m_dim2, m_dim3)" in str(exec_info.value)
 
     # wrong ddf shape
     wrong_ddf = tf.ones((batch_size, *fixed_image_size, 2), dtype="float32")
     with pytest.raises(ValueError) as exec_info:
         layer_util.warp_image_ddf(image=image, ddf=wrong_ddf, grid_ref=grid_ref)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "ddf shape must be (batch, f_dim1, f_dim2, f_dim3, 3)" in msg
+    assert "ddf shape must be (batch, f_dim1, f_dim2, f_dim3, 3)" in str(
+        exec_info.value
+    )
 
     # wrong grid_ref shape
     wrong_grid_ref = tf.ones((batch_size, *moving_image_size, 3), dtype="float32")
     with pytest.raises(ValueError) as exec_info:
         layer_util.warp_image_ddf(image=image, ddf=ddf, grid_ref=wrong_grid_ref)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "grid_ref shape must be (1, f_dim1, f_dim2, f_dim3, 3) or None" in msg
+    assert "grid_ref shape must be (1, f_dim1, f_dim2, f_dim3, 3) or None" in str(
+        exec_info.value
+    )
 
 
 def test_resize3d():
@@ -443,13 +376,13 @@ def test_resize3d():
     size = (1, 1, 1)
     with pytest.raises(ValueError) as exec_info:
         layer_util.resize3d(image=tf.ones(input_shape), size=size)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "resize3d takes input image of dimension 3 or 4 or 5" in msg
+    assert "resize3d takes input image of dimension 3 or 4 or 5" in str(exec_info.value)
 
     # Check resize3d for proper size - Fail
     input_shape = (1, 1, 1)
     size = (1, 1)
     with pytest.raises(ValueError) as exec_info:
         layer_util.resize3d(image=tf.ones(input_shape), size=size)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "resize3d takes size of type tuple/list and of length 3" in msg
+    assert "resize3d takes size of type tuple/list and of length 3" in str(
+        exec_info.value
+    )

--- a/test/unit/test_nifti_loader.py
+++ b/test/unit/test_nifti_loader.py
@@ -22,9 +22,9 @@ def test_load_nifti_file():
 
     # wrong file type
     h5_filepath = "./data/test/h5/paired/test/fixed_images.h5"
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         load_nifti_file(filepath=h5_filepath)
-    assert "Nifti file path must end with .nii or .nii.gz" in str(exec_info.value)
+    assert "Nifti file path must end with .nii or .nii.gz" in str(err_info.value)
 
 
 def test_init_sufficient_args():
@@ -92,9 +92,9 @@ def test_set_group_structure_ungrouped():
 
     loader = NiftiFileLoader(dir_path=dir_path, name=name, grouped=False)
     loader.set_group_structure()
-    with pytest.raises(AttributeError) as exec_info:
+    with pytest.raises(AttributeError) as err_info:
         loader.group_ids
-    assert "object has no attribute" in str(exec_info.value)
+    assert "object has no attribute" in str(err_info.value)
 
 
 def test_get_data_ids():
@@ -255,6 +255,6 @@ def test_get_data_incorrect_args():
 
     loader = NiftiFileLoader(dir_path=dir_path, name=name, grouped=False)
     index = "abc"
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         loader.get_data(index)
-    assert "must be int, or tuple" in str(exec_info.value)
+    assert "must be int, or tuple" in str(err_info.value)

--- a/test/unit/test_nifti_loader.py
+++ b/test/unit/test_nifti_loader.py
@@ -24,8 +24,7 @@ def test_load_nifti_file():
     h5_filepath = "./data/test/h5/paired/test/fixed_images.h5"
     with pytest.raises(ValueError) as exec_info:
         load_nifti_file(filepath=h5_filepath)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "Nifti file path must end with .nii or .nii.gz" in msg
+    assert "Nifti file path must end with .nii or .nii.gz" in str(exec_info.value)
 
 
 def test_init_sufficient_args():
@@ -95,8 +94,7 @@ def test_set_group_structure_ungrouped():
     loader.set_group_structure()
     with pytest.raises(AttributeError) as exec_info:
         loader.group_ids
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "object has no attribute" in msg
+    assert "object has no attribute" in str(exec_info.value)
 
 
 def test_get_data_ids():
@@ -259,5 +257,4 @@ def test_get_data_incorrect_args():
     index = "abc"
     with pytest.raises(ValueError) as exec_info:
         loader.get_data(index)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "must be int, or tuple" in msg
+    assert "must be int, or tuple" in str(exec_info.value)

--- a/test/unit/test_paired_loader.py
+++ b/test/unit/test_paired_loader.py
@@ -109,9 +109,9 @@ def test_validate_data_files_label():
     loader.loader_moving_label.data_keys = "foo"
     with pytest.raises(Exception) as exec_info:
         PairedDataLoader.validate_data_files(loader)
-    msg = " ".join(exec_info.value.args[0].split())
+
     loader.close()
-    assert "two lists are not identical" in msg
+    assert "two lists are not identical" in str(exec_info.value)
 
 
 def test_sample_index_generator():

--- a/test/unit/test_paired_loader.py
+++ b/test/unit/test_paired_loader.py
@@ -107,11 +107,11 @@ def test_validate_data_files_label():
 
     # alter a data ID to cause error
     loader.loader_moving_label.data_keys = "foo"
-    with pytest.raises(Exception) as exec_info:
+    with pytest.raises(Exception) as err_info:
         PairedDataLoader.validate_data_files(loader)
 
     loader.close()
-    assert "two lists are not identical" in str(exec_info.value)
+    assert "two lists are not identical" in str(err_info.value)
 
 
 def test_sample_index_generator():

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -127,16 +127,16 @@ def test_save_array():
     # test 5D np tensor
     name = "5d_np"
     arr = np.random.rand(2, 3, 4, 1, 3)
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         save_array(pair_dir=pair_dir, arr=arr, name=name, gray=True)
-    assert "arr must be 3d or 4d numpy array or tf tensor" in str(exec_info.value)
+    assert "arr must be 3d or 4d numpy array or tf tensor" in str(err_info.value)
 
     # test 4D np tensor with wrong shape
     name = "5d_np"
     arr = np.random.rand(2, 3, 4, 1)
-    with pytest.raises(ValueError) as exec_info:
+    with pytest.raises(ValueError) as err_info:
         save_array(pair_dir=pair_dir, arr=arr, name=name, gray=True)
-    assert "4d arr must have 3 channels as last dimension" in str(exec_info.value)
+    assert "4d arr must have 3 channels as last dimension" in str(err_info.value)
 
 
 def test_calculate_metrics():

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -129,16 +129,14 @@ def test_save_array():
     arr = np.random.rand(2, 3, 4, 1, 3)
     with pytest.raises(ValueError) as exec_info:
         save_array(pair_dir=pair_dir, arr=arr, name=name, gray=True)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "arr must be 3d or 4d numpy array or tf tensor" in msg
+    assert "arr must be 3d or 4d numpy array or tf tensor" in str(exec_info.value)
 
     # test 4D np tensor with wrong shape
     name = "5d_np"
     arr = np.random.rand(2, 3, 4, 1)
     with pytest.raises(ValueError) as exec_info:
         save_array(pair_dir=pair_dir, arr=arr, name=name, gray=True)
-    msg = " ".join(exec_info.value.args[0].split())
-    assert "4d arr must have 3 channels as last dimension" in msg
+    assert "4d arr must have 3 channels as last dimension" in str(exec_info.value)
 
 
 def test_calculate_metrics():


### PR DESCRIPTION
# Description

use

```
    assert "Nifti file path must end with .nii or .nii.gz" in str(exec_info.value)
```

 instead of 

```python
    msg = " ".join(exec_info.value.args[0].split())
    assert "Nifti file path must end with .nii or .nii.gz" in msg
```

also removed `check_inputs` function, as now with tests, this is no longer needed

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
