### PR TITLE
296 broken edu links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,5 @@ For guidance on making a contribution to DeepReg, see the
 - Issue tracker: https://github.com/DeepRegNet/DeepReg/issues
 
 The **MICCAI Educational Challenge** notebook can be accessed
-[here](./docs/Intro_to_Medical_Image_Regsitration.ipynb) or run it on
-[Colab](https://colab.research.google.com/github/DeepRegNet/DeepReg/tree/master/docs/Intro_to_Medical_Image_Regsitration.ipynb).
+[here](./docs/Intro_to_Medical_Image_Registration.ipynb) or run it on
+[Colab](https://colab.research.google.com/github/DeepRegNet/DeepReg/tree/master/docs/Intro_to_Medical_Image_Registration.ipynb).

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ For guidance on making a contribution to DeepReg, see the
 
 The **MICCAI Educational Challenge** notebook can be accessed
 [here](./docs/Intro_to_Medical_Image_Registration.ipynb) or run it on
-[Colab](https://colab.research.google.com/github/DeepRegNet/DeepReg/tree/master/docs/Intro_to_Medical_Image_Registration.ipynb).
+[Colab](https://colab.research.google.com/github/DeepRegNet/DeepReg/tree/blob/master/docs/Intro_to_Medical_Image_Registration.ipynb).

--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ For guidance on making a contribution to DeepReg, see the
 
 The **MICCAI Educational Challenge** notebook can be accessed
 [here](./docs/Intro_to_Medical_Image_Registration.ipynb) or run it on
-[Colab](https://colab.research.google.com/github/DeepRegNet/DeepReg/tree/blob/master/docs/Intro_to_Medical_Image_Registration.ipynb).
+[Colab](https://colab.research.google.com/github/DeepRegNet/DeepReg/blob/master/docs/Intro_to_Medical_Image_Registration.ipynb).


### PR DESCRIPTION
# Description

Broken links to jupyter notebook due to wrong filename and wrong path to colab.

Fixes #266 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Checked links not broken by clicking from amended README
