### PR TITLE
Issue #279: revert dir path change [skip ci]

### DIFF
--- a/docs/Intro_to_Medical_Image_Registration.ipynb
+++ b/docs/Intro_to_Medical_Image_Registration.ipynb
@@ -397,7 +397,7 @@
       "source": [
         "# Import medical data - we are going to use the head and neck CT data to show the losses.\n",
         "MAIN_PATH = os.getcwd()\n",
-        "PROJECT_DIR = os.path.join(MAIN_PATH, \"demos/classical_ct_headneck_affine\")\n",
+        "PROJECT_DIR = os.path.join(MAIN_PATH, \"demos/classical_ct_headandneck_affine\")\n",
         "\n",
         "DATA_PATH = \"dataset\"\n",
         "FILE_PATH = os.path.abspath(os.path.join(PROJECT_DIR, DATA_PATH, \"demo.h5\"))\n",


### PR DESCRIPTION
# Description

Revert path change in notebook.

Later if we want to update notebook, we should

1. Comment out the switch to tag code in notebook
2. Adapt the notebook to latest master
3. All working, move the tag
4. Push the notebook 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
