### PR TITLE
Issue #312: modified broken links to readthedocs and the images

### DIFF
--- a/docs/Intro_to_Medical_Image_Registration.ipynb
+++ b/docs/Intro_to_Medical_Image_Registration.ipynb
@@ -309,7 +309,7 @@
         "\n",
         "When multiple labels are available for each image, the labels can be sampled during training, such that only one label per image is used in each iteration of the data set (epoch). We expand on this for different dataset loaders in the [DeepReg dataset loader API](https://deepreg.readthedocs.io/en/latest/api/loader.html#) but do not need this for the tutorials in this notebook.\n",
         "\n",
-        "![Unsupervised DDF-based registration network](https://github.com/DeepRegNet/DeepReg/blob/master/docs/source/_images/registration-ddf-nn-unsupervised.svg)\n",
+        "![Unsupervised DDF-based registration network](https://github.com/DeepRegNet/DeepReg/blob/master/docs/source/_images/registration-ddf-nn-unsupervised.svg?raw=true)\n",
         "\n",
         "The loss function often consists of the intensity-based loss and deformation loss.\n",
         "\n",
@@ -321,7 +321,7 @@
         "\n",
         "When multiple labels are available for each image, the labels can be sampled during training, such that only one label per image is used in each iteration of the data set (epoch). Details are again provided in the [DeepReg dataset loader API](https://deepregnet.github.io/DeepReg/#/doc_data_loader) but not required for the tutorials.\n",
         "\n",
-        "![Weakly-supervised DDF-based registration network](https://github.com/DeepRegNet/DeepReg/blob/master/docs/source/_images/registration-ddf-nn-weakly-supervised.svg)\n",
+        "![Weakly-supervised DDF-based registration network](https://github.com/DeepRegNet/DeepReg/blob/master/docs/source/_images/registration-ddf-nn-weakly-supervised.svg?raw=true)\n",
         "\n",
         "### Combined\n",
         "\n",
@@ -330,7 +330,7 @@
         "unsupervised and weakly supervised methods. Following is an illustration of a combined\n",
         "DDF-based registration network.\n",
         "\n",
-        "![Combined DDF-based registration network](https://github.com/DeepRegNet/DeepReg/blob/master/docs/source/_images/registration-ddf-nn-combined.svg)\n"
+        "![Combined DDF-based registration network](https://github.com/DeepRegNet/DeepReg/blob/master/docs/source/_images/registration-ddf-nn-combined.svg?raw=true)\n"
       ]
     },
     {


### PR DESCRIPTION
# Description

Fixed broken links from github pages to readthedocs, added links to broken images.

Fixes #312

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
