### PR TITLE
Issue #316 github.io links updated to readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ and education in medical image registration using deep learning.**
 
 ## Getting Started
 
-- [Documentation, tutorials and a quick start guide](https://deepregnet.github.io/DeepReg/#)
-- [DeepReg Demos](https://deepregnet.github.io/DeepReg/#/tutorial_demo)
+- [Documentation, tutorials and a quick start guide](https://deepreg.readthedocs.io/)
+- [DeepReg Demos](https://deepreg.readthedocs.io/en/latest/demo/introduction.html)
 - Code: https://github.com/DeepRegNet/DeepReg
 - Issue tracker: https://github.com/DeepRegNet/DeepReg/issues
 - Website: http://deepreg.net/
@@ -39,11 +39,11 @@ and education in medical image registration using deep learning.**
 Get involved, and help make DeepReg better!
 
 For guidance on making a contribution to DeepReg, see the
-[contribution guidelines](https://deepregnet.github.io/DeepReg/#/CONTRIBUTING).
+[contribution guidelines](https://deepreg.readthedocs.io/en/latest/contributing/code.html).
 
 If you identified a registration application with openly accessible data, please
 consider
-[contributing a DeepReg Demo](https://deepregnet.github.io/DeepReg/#/doc_demo_requirement).
+[contributing a DeepReg Demo](https://deepreg.readthedocs.io/en/latest/contributing/demo.html).
 
 ## MICCAI 2020 Educational Challenge
 

--- a/deepreg/dataset/loader/grouped_loader.py
+++ b/deepreg/dataset/loader/grouped_loader.py
@@ -2,7 +2,7 @@
 Loads grouped data
 supports h5 and nifti formats
 supports labeled and unlabeled data
-Read https://ucl-candi.github.io/DeepReg/#/doc_data_loader?id=grouped-images for more details.
+Read https://deepreg.readthedocs.io/en/latest/api/loader.html#module-deepreg.dataset.loader.grouped_loader for more details.
 """
 import random
 from typing import List

--- a/demos/grouped_mask_prostate_longitudinal/README.md
+++ b/demos/grouped_mask_prostate_longitudinal/README.md
@@ -22,7 +22,7 @@ and monitoring potential cancerous regions.
 
 ## Instruction
 
-- [Install DeepReg](https://deepregnet.github.io/DeepReg/#/quick_start?id=install-the-package);
+- [Install DeepReg](https://deepreg.readthedocs.io/en/latest/getting_started/install.html);
 - Change current directory to the root directory of DeepReg project;
 - Run [demo_data.py](./demo_data.py) script to download example 10 folds of unpaired 3D
   ultrasound images and the pre-trained model.
@@ -36,7 +36,7 @@ python demos/grouped_mask_prostate_longitudinal/demo_data.py
   [`dataset` section](./grouped_mask_prostate_longitudinal_dataset0.yaml) and the
   [`train` section](./grouped_mask_prostate_longitudinal_train.yaml), which can be
   specified in
-  [seperate yaml files](https://deepregnet.github.io/DeepReg/#/tutorial_experiment?id=cross-validation);
+  [separate yaml files](https://deepreg.readthedocs.io/en/latest/tutorial/cross_val.html);
 
 ```bash
 deepreg_train --gpu "0" --config_path demos/grouped_mask_prostate_longitudinal/grouped_mask_prostate_longitudinal.yaml --log_dir grouped_mask_prostate_longitudinal

--- a/demos/paired_ct_lung/README.md
+++ b/demos/paired_ct_lung/README.md
@@ -16,7 +16,7 @@ tumor location when conducting invasive procedures.
 
 ## Instructions
 
-- [Install DeepReg](https://deepregnet.github.io/DeepReg/#/quick_start?id=install-the-package);
+- [Install DeepReg](https://deepreg.readthedocs.io/en/latest/getting_started/install.html);
 - Change current directory to the root directory of DeepReg project;
 - The `demo_data.py`, `demo_train.py` and `demo_predict.py` scripts need to be run using
   the following command:

--- a/demos/paired_mrus_brain/README.md
+++ b/demos/paired_mrus_brain/README.md
@@ -16,7 +16,7 @@ from imaging such as MR.
 
 ## Instructions
 
-- [Install DeepReg](https://deepregnet.github.io/DeepReg/#/quick_start?id=install-the-package);
+- [Install DeepReg](https://deepreg.readthedocs.io/en/latest/getting_started/install.html);
 - Change current directory to the root directory of DeepReg project;
 - The `demo_data.py`, `demo_train.py` and `demo_predict.py` scripts need to be run using
   the following command:

--- a/demos/paired_mrus_prostate/README.md
+++ b/demos/paired_mrus_prostate/README.md
@@ -25,7 +25,7 @@ driven by expert-defined anatomical landmarks, such as the prostate gland segmen
 
 ## Instruction
 
-- [Install DeepReg](https://deepregnet.github.io/DeepReg/#/quick_start?id=install-the-package);
+- [Install DeepReg](https://deepreg.readthedocs.io/en/latest/getting_started/install.html);
 - Change current directory to the root directory of DeepReg project;
 - Run [demo_data.py](./demo_data.py) script to download example 10 folds of unpaired 3D
   ultrasound images and the pre-trained model.
@@ -38,7 +38,7 @@ python demos/paired_mrus_prostate/demo_data.py
   launches the first of the ten runs of a 9-fold cross-validation, as specified in the
   [`dataset` section](./paired_mrus_prostate_dataset0.yaml) and the
   [`train` section](./paired_mrus_prostate_train.yaml), which can be specified in
-  [seperate yaml files](https://deepregnet.github.io/DeepReg/#/tutorial_experiment?id=cross-validation);
+  [separate yaml files](https://deepreg.readthedocs.io/en/latest/tutorial/cross_val.html);
 
 ```bash
 deepreg_train --gpu "1, 2" --config_path demos/paired_mrus_prostate/paired_mrus_prostate_dataset0.yaml demos/paired_mrus_prostate/paired_mrus_prostate_train.yaml --log_dir paired_mrus_prostate

--- a/demos/unpaired_ct_lung/README.md
+++ b/demos/unpaired_ct_lung/README.md
@@ -18,7 +18,7 @@ application can be seen in [2].
 
 ## Instructions
 
-- [Install DeepReg](https://deepregnet.github.io/DeepReg/#/quick_start?id=install-the-package);
+- [Install DeepReg](https://deepreg.readthedocs.io/en/latest/getting_started/install.html);
 - Change current directory to the root directory of DeepReg project;
 - The `demo_data.py`, `demo_train.py` and `demo_predict.py` scripts need to be run using
   the following command:

--- a/demos/unpaired_mr_brain/README.md
+++ b/demos/unpaired_mr_brain/README.md
@@ -15,7 +15,7 @@ composite loss of image and label similarity.
 
 ## Instructions
 
-- [Install DeepReg](https://deepregnet.github.io/DeepReg/#/quick_start?id=install-the-package);
+- [Install DeepReg](https://deepreg.readthedocs.io/en/latest/getting_started/install.html);
 - Change current directory to the root directory of DeepReg project;
 - The `demo_data.py`, `demo_train.py` and `demo_predict.py` scripts need to be run using
   the following command:

--- a/demos/unpaired_us_prostate_cv/README.md
+++ b/demos/unpaired_us_prostate_cv/README.md
@@ -21,7 +21,7 @@ dataset/fold3 dataset/fold4 dataset/fold5 dataset/fold6 dataset/fold7 dataset/fo
 dataset/fold9 --prefix unpaired_us_prostate_cv_run
 -->
 
-- [Install DeepReg](https://deepregnet.github.io/DeepReg/#/quick_start?id=install-the-package);
+- [Install DeepReg](https://deepreg.readthedocs.io/en/latest/getting_started/install.html);
 - Change current directory to the root directory of DeepReg project;
 - Run `demo_data.py` script to download example 10 folds of unpaired 3D ultrasound
   images;
@@ -34,7 +34,7 @@ python demos/unpaired_us_prostate_cv/demo_data.py
   launches the first of the ten runs of a 9-fold cross-validation, as specified in the
   [`dataset` section](./unpaired_us_prostate_cv_run1.yaml) and the
   [`train` section](./unpaired_us_prostate_cv_train.yaml), which can be specified in
-  [seperate yaml files](https://deepregnet.github.io/DeepReg/#/tutorial_experiment?id=cross-validation).
+  [separate yaml files](https://deepreg.readthedocs.io/en/latest/tutorial/cross_val.html).
   The 10th fold is reserved for testing;
 
 ```bash

--- a/docs/Intro_to_Medical_Image_Registration.ipynb
+++ b/docs/Intro_to_Medical_Image_Registration.ipynb
@@ -319,7 +319,7 @@
         "\n",
         "Combined with the regularisation on the predicted displacement field, this forms a weakly-supervised training. An illustration of a weakly-supervised DDF-based registration network is provided below.\n",
         "\n",
-        "When multiple labels are available for each image, the labels can be sampled during training, such that only one label per image is used in each iteration of the data set (epoch). Details are again provided in the [DeepReg dataset loader API](https://deepregnet.github.io/DeepReg/#/doc_data_loader) but not required for the tutorials.\n",
+        "When multiple labels are available for each image, the labels can be sampled during training, such that only one label per image is used in each iteration of the data set (epoch). Details are again provided in the [DeepReg dataset loader API](https://deepreg.readthedocs.io/en/latest/docs/dataset_loader.html) but not required for the tutorials.\n",
         "\n",
         "![Weakly-supervised DDF-based registration network](https://github.com/DeepRegNet/DeepReg/blob/master/docs/source/_images/registration-ddf-nn-weakly-supervised.svg?raw=true)\n",
         "\n",

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -76,8 +76,8 @@ Wellcome/EPSRC Centre for Medical Engineering (`CME`_).
     :alt: CME Logo
 
 .. _TensorFlow2: https://www.tensorflow.org/
-.. _DeepReg Demos: https://deepregnet.github.io/DeepReg/#/tutorial_demo
-.. _documentation and tutorials: https://deepregnet.github.io/DeepReg/
+.. _DeepReg Demos: https://deepreg.readthedocs.io/en/latest/demo/introduction.html
+.. _Documentation and tutorials: https://deepreg.readthedocs.io/
 .. _Get involved: CONTRIBUTING.md
 .. _WEISS: https://www.ucl.ac.uk/interventional-surgical-sciences/
 .. _CME: https://medicalengineering.org.uk/

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -67,17 +67,17 @@ Surgical Sciences (`WEISS`_), and partial support from the
 Wellcome/EPSRC Centre for Medical Engineering (`CME`_).
 
 .. image:: https://raw.githubusercontent.com/DeepRegNet/DeepReg/master/docs/asset/weiss.jpg
-    :height: 80px
+    :width: 400
     :alt: WEISS Logo
 
 
 .. image:: https://raw.githubusercontent.com/DeepRegNet/DeepReg/master/docs/asset/medicalengineering.svg
-    :height: 80px
+    :width: 400
     :alt: CME Logo
 
 .. _TensorFlow2: https://www.tensorflow.org/
 .. _DeepReg Demos: https://deepreg.readthedocs.io/en/latest/demo/introduction.html
 .. _Documentation and tutorials: https://deepreg.readthedocs.io/
-.. _Get involved: CONTRIBUTING.md
+.. _Get involved: https://deepreg.readthedocs.io/en/latest/contributing/issue.html
 .. _WEISS: https://www.ucl.ac.uk/interventional-surgical-sciences/
 .. _CME: https://medicalengineering.org.uk/

--- a/docs/source/tutorial/custom_loss.md
+++ b/docs/source/tutorial/custom_loss.md
@@ -7,8 +7,8 @@ an example to show how to add a new loss to DeepReg.
 
 Three main types of the loss functions are supported in DeepReg:
 `intensity (image) based loss`, `label based loss` and `deformation loss`. See
-[Docs here](https://deepregnet.github.io/DeepReg/#/tutorial_registration?id=loss) for
-details. The correspondng source files for the losses is included in
+[Docs here](https://deepreg.readthedocs.io/en/latest/tutorial/registration.html#loss)
+for details. The correspondng source files for the losses is included in
 `deepreg/model/loss`.
 
 ## Step 1: Add the new function in loss source code
@@ -64,7 +64,8 @@ def dissimilarity_fn(
 Add correspoding unit test for the new added functions to `deepreg/test/unit`. It's just
 optional for the users. Everyone is warmly welcome to make contribution to DeepReg.
 Please follow our
-[contribution guidelines](https://deepregnet.github.io/DeepReg/#/CONTRIBUTING) here.
+[contribution guidelines](https://deepreg.readthedocs.io/en/latest/contributing/code.html)
+here.
 
 ## Step 3: Set yaml configuration files
 


### PR DESCRIPTION
# Description

all the github.io links are updated to readthedocs.io

Fixes #316 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation updates 
