### PR TITLE
Issue #350: set unpaired_ct_lung to use gpu by default and fix readme

### DIFF
--- a/demos/unpaired_ct_lung/README.md
+++ b/demos/unpaired_ct_lung/README.md
@@ -63,6 +63,10 @@ following order:
 
 Last commit at which demo was tested: c709a46c345552ae1396e6d7ba46a44f7950aea0
 
+Note: This demo was tested using one Nvidia Tesla V100 GPU with a memory of 32GB. Please
+ensure that enough memory is available to run the demo otherwise memory allocation
+errors might arise.
+
 ## References
 
 [1] Hering A, Murphy K, and van Ginneken B. (2020). Lean2Reg Challenge: CT Lung

--- a/demos/unpaired_ct_lung/demo_train.py
+++ b/demos/unpaired_ct_lung/demo_train.py
@@ -2,7 +2,7 @@ from deepreg.train import train
 
 ######## NOW WE DO THE TRAINING ########
 
-gpu = ""
+gpu = "0"
 gpu_allow_growth = False
 ckpt_path = ""
 log_dir = "learn2reg_t2_unpaired_train_logs"


### PR DESCRIPTION
# Description

unpaired_ct_lung demo uses gpu by default and a note on memory usage has been added to the readme.

Fixes #350 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
