### PR TITLE
Issue #398: add log_root param to replace hard-coded logs

### DIFF
--- a/deepreg/predict.py
+++ b/deepreg/predict.py
@@ -211,11 +211,14 @@ def predict_on_dataset(
     save_metric_dict(save_dir=save_dir, metrics=metric_lists)
 
 
-def build_config(config_path: (str, list), log_dir: str, ckpt_path: str) -> [dict, str]:
+def build_config(
+    config_path: (str, list), log_root: str, log_dir: str, ckpt_path: str
+) -> [dict, str]:
     """
     Function to create new directory to log directory to store results.
 
     :param config_path: string or list of strings, path of configuration files
+    :param log_root: str, root of logs
     :param log_dir: string, path to store logs.
     :param ckpt_path: str, path where model is stored.
     :return: - config, configuration dictionary
@@ -228,7 +231,7 @@ def build_config(config_path: (str, list), log_dir: str, ckpt_path: str) -> [dic
         )
 
     # init log directory
-    log_dir = build_log_dir(log_dir)
+    log_dir = build_log_dir(log_root=log_root, log_dir=log_dir)
 
     # load config
     if config_path == "":
@@ -257,6 +260,7 @@ def predict(
     config_path: (str, list),
     save_nifti: bool = True,
     save_png: bool = True,
+    log_root: str = "logs",
 ):
     """
     Function to predict some metrics from the saved model and logging results.
@@ -283,7 +287,7 @@ def predict(
 
     # load config
     config, log_dir = build_config(
-        config_path=config_path, log_dir=log_dir, ckpt_path=ckpt_path
+        config_path=config_path, log_root=log_root, log_dir=log_dir, ckpt_path=ckpt_path
     )
     preprocess_config = config["train"]["preprocess"]
     preprocess_config["batch_size"] = batch_size
@@ -386,6 +390,10 @@ def main(args=None):
     )
 
     parser.add_argument(
+        "--log_root", help="Root of log directory.", default="logs", type=str
+    )
+
+    parser.add_argument(
         "--log_dir", "-l", help="Path of log directory", default="", type=str
     )
 
@@ -418,16 +426,17 @@ def main(args=None):
     args = parser.parse_args(args)
 
     predict(
-        args.gpu,
-        args.gpu_allow_growth,
-        args.ckpt_path,
-        args.mode,
-        args.batch_size,
-        args.log_dir,
-        args.sample_label,
-        args.config_path,
-        args.nifti,
-        args.png,
+        gpu=args.gpu,
+        gpu_allow_growth=args.gpu_allow_growth,
+        ckpt_path=args.ckpt_path,
+        mode=args.mode,
+        batch_size=args.batch_size,
+        log_root=args.log_root,
+        log_dir=args.log_dir,
+        sample_label=args.sample_label,
+        config_path=args.config_path,
+        save_nifti=args.nifti,
+        save_png=args.png,
     )
 
 

--- a/deepreg/train.py
+++ b/deepreg/train.py
@@ -15,13 +15,16 @@ from deepreg.model.network.build import build_model
 from deepreg.util import build_dataset, build_log_dir
 
 
-def build_config(config_path: (str, list), log_dir: str, ckpt_path: str) -> [dict, str]:
+def build_config(
+    config_path: (str, list), log_root: str, log_dir: str, ckpt_path: str
+) -> [dict, str]:
     """
     Function to initialise log directories,
     assert that checkpointed model is the right
     type and to parse the configuration for training
 
     :param config_path: list of str, path to config file
+    :param log_root: str, root of logs
     :param log_dir: str, path to where training logs to be stored.
     :param ckpt_path: str, path where model is stored.
     :return: - config: a dictionary saving configuration
@@ -29,7 +32,7 @@ def build_config(config_path: (str, list), log_dir: str, ckpt_path: str) -> [dic
     """
 
     # init log directory
-    log_dir = build_log_dir(log_dir)
+    log_dir = build_log_dir(log_root=log_root, log_dir=log_dir)
 
     # check checkpoint path
     if ckpt_path != "":
@@ -68,6 +71,7 @@ def train(
     gpu_allow_growth: bool,
     ckpt_path: str,
     log_dir: str,
+    log_root: str = "logs",
 ):
     """
     Function to train a model
@@ -76,6 +80,7 @@ def train(
     :param config_path: str, path to configuration set up
     :param gpu_allow_growth: bool, whether or not to allocate whole GPU memory to training
     :param ckpt_path: str, where to store training checkpoints
+    :param log_root: str, root of logs
     :param log_dir: str, where to store logs in training
     """
     # set env variables
@@ -84,7 +89,7 @@ def train(
 
     # load config
     config, log_dir = build_config(
-        config_path=config_path, log_dir=log_dir, ckpt_path=ckpt_path
+        config_path=config_path, log_root=log_root, log_dir=log_dir, ckpt_path=ckpt_path
     )
 
     # build dataset
@@ -191,9 +196,13 @@ def main(args=None):
     )
 
     parser.add_argument(
+        "--log_root", help="Root of log directory.", default="logs", type=str
+    )
+
+    parser.add_argument(
         "--log_dir",
         "-l",
-        help="Name of log directory. The directory is under logs/."
+        help="Name of log directory. The directory is under log root, e.g. logs/ by default."
         "If not provided, a timestamp based folder will be created.",
         default="",
         type=str,
@@ -210,7 +219,12 @@ def main(args=None):
 
     args = parser.parse_args(args)
     train(
-        args.gpu, args.config_path, args.gpu_allow_growth, args.ckpt_path, args.log_dir
+        gpu=args.gpu,
+        config_path=args.config_path,
+        gpu_allow_growth=args.gpu_allow_growth,
+        ckpt_path=args.ckpt_path,
+        log_root=args.log_root,
+        log_dir=args.log_dir,
     )
 
 

--- a/deepreg/util.py
+++ b/deepreg/util.py
@@ -47,13 +47,14 @@ def build_dataset(
     return data_loader, dataset, steps_per_epoch
 
 
-def build_log_dir(log_dir: str) -> str:
+def build_log_dir(log_root: str, log_dir: str) -> str:
     """
+    :param log_root: str, root of logs
     :param log_dir: str, path to where training logs to be stored.
     :return: the path of directory to save logs
     """
     log_dir = os.path.join(
-        "logs", datetime.now().strftime("%Y%m%d-%H%M%S") if log_dir == "" else log_dir
+        log_root, datetime.now().strftime("%Y%m%d-%H%M%S") if log_dir == "" else log_dir
     )
     if os.path.exists(log_dir):
         logging.warning("Log directory {} exists already.".format(log_dir))

--- a/docs/source/docs/cli.md
+++ b/docs/source/docs/cli.md
@@ -64,11 +64,21 @@ configuration can be specified in the configuration file. Please see
 
   - `--ckpt_path weights-epoch2.ckpt` for reloading the given checkpoint.
 
+- **Output root**:
+
+  `--log_root`, specifies the directory for saving all logs.
+
+  By default it is `logs` under the root of package.
+
+  Example usage:
+
+  - `--log_root /logs` for saving all logs under `/logs`.
+
 - **Output directory**:
 
   `--log_dir` or `-l`, specifies the directory name to save logs.
 
-  The directory will be under `logs/`.
+  The directory will be under the `log_root` which is `logs` by default.
 
   By default it creates a timestamp-named directory, e.g. `logs/20200810-194042/`.
 
@@ -139,13 +149,23 @@ configuration can be specified in the configuration file. Please see
 
   - `--gpu_allow_growth`, no extra argument is needed.
 
+- **Output root**:
+
+  `--log_root`, specifies the directory for saving all logs.
+
+  By default it is `logs` under the root of package.
+
+  Example usage:
+
+  - `--log_root /logs` for saving all logs under `/logs`.
+
 - **Output directory**:
 
   `--log_dir` or `-l`, specifies the directory name to save logs.
 
-  The directory will be under `logs/`.
+  The directory will be under the `log_root` which is `logs` by default.
 
-  By default is creates a timestamp-named directory like `logs/20200810-194042/`.
+  By default it creates a timestamp-named directory, e.g. `logs/20200810-194042/`.
 
   Example usage:
 

--- a/test/unit/test_predict.py
+++ b/test/unit/test_predict.py
@@ -12,6 +12,8 @@ import pytest
 
 from deepreg.predict import build_config, build_pair_output_path
 
+log_root = "logs"
+
 
 def test_build_pair_output_path():
     """
@@ -51,14 +53,22 @@ def test_build_config():
 
     # checkpoint path ends with ckpt
     got_config, got_log_dir = build_config(
-        config_path=config_path, log_dir=log_dir, ckpt_path="example.ckpt"
+        config_path=config_path,
+        log_root=log_root,
+        log_dir=log_dir,
+        ckpt_path="example.ckpt",
     )
     assert isinstance(got_config, dict)
     assert got_log_dir == os.path.join("logs", log_dir)
 
     # checkpoint path ends with h5
     with pytest.raises(ValueError):
-        build_config(config_path=config_path, log_dir=log_dir, ckpt_path="example.h5")
+        build_config(
+            config_path=config_path,
+            log_root=log_root,
+            log_dir=log_dir,
+            ckpt_path="example.h5",
+        )
 
 
 def test_predict_on_dataset():

--- a/test/unit/test_train.py
+++ b/test/unit/test_train.py
@@ -14,6 +14,8 @@ from deepreg.predict import main as predict_main
 from deepreg.train import build_callbacks, build_config
 from deepreg.train import main as train_main
 
+log_root = "logs"
+
 
 def test_build_config():
     """
@@ -24,21 +26,29 @@ def test_build_config():
 
     # checkpoint path empty
     got_config, got_log_dir = build_config(
-        config_path=config_path, log_dir=log_dir, ckpt_path=""
+        config_path=config_path, log_root=log_root, log_dir=log_dir, ckpt_path=""
     )
     assert isinstance(got_config, dict)
-    assert got_log_dir == os.path.join("logs", log_dir)
+    assert got_log_dir == os.path.join(log_root, log_dir)
 
     # checkpoint path ends with ckpt
     got_config, got_log_dir = build_config(
-        config_path=config_path, log_dir=log_dir, ckpt_path="example.ckpt"
+        config_path=config_path,
+        log_root=log_root,
+        log_dir=log_dir,
+        ckpt_path="example.ckpt",
     )
     assert isinstance(got_config, dict)
-    assert got_log_dir == os.path.join("logs", log_dir)
+    assert got_log_dir == os.path.join(log_root, log_dir)
 
     # checkpoint path ends with h5
     with pytest.raises(ValueError):
-        build_config(config_path=config_path, log_dir=log_dir, ckpt_path="example.h5")
+        build_config(
+            config_path=config_path,
+            log_root=log_root,
+            log_dir=log_dir,
+            ckpt_path="example.h5",
+        )
 
 
 def test_build_callbacks():

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -19,6 +19,8 @@ from deepreg.util import (
     save_metric_dict,
 )
 
+log_root = "logs"
+
 
 def test_build_dataset():
     """
@@ -27,12 +29,13 @@ def test_build_dataset():
 
     # init arguments
     config_path = "config/unpaired_labeled_ddf.yaml"
+    log_root = "logs"
     log_dir = "test_build_dataset"
     ckpt_path = ""
 
     # load config
     config, log_dir = build_config(
-        config_path=config_path, log_dir=log_dir, ckpt_path=ckpt_path
+        config_path=config_path, log_root=log_root, log_dir=log_dir, ckpt_path=ckpt_path
     )
 
     # build dataset
@@ -72,16 +75,16 @@ def test_build_log_dir():
     """
 
     # use default timestamp based directory
-    log_dir = build_log_dir(log_dir="")
+    log_dir = build_log_dir(log_root=log_root, log_dir="")
     head, tail = os.path.split(log_dir)
-    assert head == "logs"
+    assert head == log_root
     pattern = re.compile("[0-9]{8}-[0-9]{6}")
     assert pattern.match(tail)
 
     # use custom directory
-    log_dir = build_log_dir(log_dir="custom")
+    log_dir = build_log_dir(log_root=log_root, log_dir="custom")
     head, tail = os.path.split(log_dir)
-    assert head == "logs"
+    assert head == log_root
     assert tail == "custom"
 
 

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -19,8 +19,6 @@ from deepreg.util import (
     save_metric_dict,
 )
 
-log_root = "logs"
-
 
 def test_build_dataset():
     """
@@ -69,23 +67,22 @@ def test_build_dataset():
     assert steps_per_epoch_valid is None
 
 
-def test_build_log_dir():
+@pytest.mark.parametrize("log_root,log_dir", [("logs", ""), ("logs", "custom")])
+def test_build_log_dir(log_root: str, log_dir: str):
     """
     Test build_log_dir for default directory and custom directory
     """
 
-    # use default timestamp based directory
-    log_dir = build_log_dir(log_root=log_root, log_dir="")
-    head, tail = os.path.split(log_dir)
+    built_log_dir = build_log_dir(log_root=log_root, log_dir=log_dir)
+    head, tail = os.path.split(built_log_dir)
     assert head == log_root
-    pattern = re.compile("[0-9]{8}-[0-9]{6}")
-    assert pattern.match(tail)
-
-    # use custom directory
-    log_dir = build_log_dir(log_root=log_root, log_dir="custom")
-    head, tail = os.path.split(log_dir)
-    assert head == log_root
-    assert tail == "custom"
+    if log_dir == "":
+        # use default timestamp based directory
+        pattern = re.compile("[0-9]{8}-[0-9]{6}")
+        assert pattern.match(tail)
+    else:
+        # use custom directory
+        assert tail == log_dir
 
 
 def test_save_array():


### PR DESCRIPTION
# Description

Add `log_root` argument for `train` and `predict` functions and corresponding CLI tools so that
logs do not have to be under the root of package.

Fixes #398

## Type of change

What types of changes does your code introduce to DeepReg? _Put an `x` in the boxes that
apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [x] Documentation Update (fix or improvement on the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask. We're here to help! This is
simply a reminder of what we are going to look for before merging your code._

- [x] I have
      [installed pre-commit](https://deepreg.readthedocs.io/en/latest/contributing/setup.html)
      and formatted all changed files.
- [x] My commits' message styles matches
      [our requested structure](https://deepreg.readthedocs.io/en/latest/contributing/commit.html),
      e.g. `Issue #<issue number>: detailed message`.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
