### PR TITLE
Issue #452: use eps instead of div_no_nan for division

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,8 @@ simply a reminder of what we are going to look for before merging your code._
 
 - [ ] I have
       [installed pre-commit](https://deepreg.readthedocs.io/en/latest/contributing/setup.html)
-      and formatted all changed files.
+      using `pre-commit install` and formatted all changed files. If you are not
+      certain, run `pre-commit run --all-files`.
 - [ ] My commits' message styles matches
       [our requested structure](https://deepreg.readthedocs.io/en/latest/contributing/commit.html),
       e.g. `Issue #<issue number>: detailed message`.

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ logs/
 
 # data folders
 *.tfrecords
+demos/*/dataset
+demos/grouped_mr_heart/myops.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ straightforward as possible.
 
 ### Fixed
 
+- Fixed division by zero handling in multiple image/label losses.
 - Fixed tensor comparison in unit tests and impacted tests.
 - Removed normalization of DDF/DVF when saving in Nifti formats.
 - Fixed invalid link in the quick start page.

--- a/deepreg/model/loss/image.py
+++ b/deepreg/model/loss/image.py
@@ -97,7 +97,7 @@ def local_normalized_cross_correlation(
     cross = tp_sum - p_avg * t_sum
     t_var = t2_sum - t_avg * t_sum  # std[t] ** 2
     p_var = p2_sum - p_avg * p_sum  # std[p] ** 2
-    ncc = (cross * cross + EPS) / (t_var * p_var + EPS)
+    ncc = (cross * cross) / (t_var * p_var + EPS)
     return tf.reduce_mean(ncc, axis=[1, 2, 3, 4])
 
 
@@ -161,5 +161,5 @@ def global_mutual_information(
     pab /= nb_voxels
 
     # MI: sum(P_ab * log(P_ab/P_aP_b))
-    div = (pab + EPS) / (papb + EPS) + EPS
-    return tf.reduce_sum(pab * tf.math.log(div), axis=[1, 2])
+    div = pab / (papb + EPS)
+    return tf.reduce_sum(pab * tf.math.log(div + EPS), axis=[1, 2])

--- a/deepreg/model/loss/image.py
+++ b/deepreg/model/loss/image.py
@@ -48,8 +48,6 @@ def local_normalized_cross_correlation(
     - Zero-normalized cross-correlation (ZNCC): https://en.wikipedia.org/wiki/Cross-correlation
     - Code: https://github.com/voxelmorph/voxelmorph/blob/legacy/src/losses.py
 
-    TODO: is it possible to not using tf.nn.conv3d?
-
     :param y_true: shape = (batch, dim1, dim2, dim3, ch)
     :param y_pred: shape = (batch, dim1, dim2, dim3, ch)
     :param kernel_size: int
@@ -97,7 +95,7 @@ def local_normalized_cross_correlation(
     cross = tp_sum - p_avg * t_sum
     t_var = t2_sum - t_avg * t_sum  # std[t] ** 2
     p_var = p2_sum - p_avg * p_sum  # std[p] ** 2
-    ncc = (cross * cross) / (t_var * p_var + EPS)
+    ncc = (cross * cross + EPS) / (t_var * p_var + EPS)
     return tf.reduce_mean(ncc, axis=[1, 2, 3, 4])
 
 
@@ -161,5 +159,5 @@ def global_mutual_information(
     pab /= nb_voxels
 
     # MI: sum(P_ab * log(P_ab/P_aP_b))
-    div = pab / (papb + EPS)
+    div = (pab + EPS) / (papb + EPS)
     return tf.reduce_sum(pab * tf.math.log(div + EPS), axis=[1, 2])

--- a/deepreg/model/loss/label.py
+++ b/deepreg/model/loss/label.py
@@ -168,7 +168,7 @@ def dice_score(y_true: tf.Tensor, y_pred: tf.Tensor, binary: bool = False) -> tf
     denominator = tf.reduce_sum(y_true, axis=[1, 2, 3]) + tf.reduce_sum(
         y_pred, axis=[1, 2, 3]
     )
-    return numerator / (denominator + EPS)
+    return (numerator + EPS) / (denominator + EPS)
 
 
 def dice_score_generalized(
@@ -203,7 +203,7 @@ def dice_score_generalized(
         (pos_weight + neg_weight) * y_prod - neg_weight * y_sum + neg_weight
     )
     denominator = (pos_weight - neg_weight) * y_sum + 2 * neg_weight
-    return numerator / (denominator + EPS)
+    return (numerator + EPS) / (denominator + EPS)
 
 
 def jaccard_index(y_true: tf.Tensor, y_pred: tf.Tensor) -> tf.Tensor:
@@ -224,7 +224,7 @@ def jaccard_index(y_true: tf.Tensor, y_pred: tf.Tensor) -> tf.Tensor:
         + tf.reduce_sum(y_pred, axis=[1, 2, 3])
         - numerator
     )
-    return numerator / (denominator + EPS)
+    return (numerator + EPS) / (denominator + EPS)
 
 
 def gauss_kernel1d(sigma: int) -> tf.Tensor:
@@ -308,7 +308,7 @@ def compute_centroid(mask: tf.Tensor, grid: tf.Tensor) -> tf.Tensor:
     )  # (batch, dim1, dim2, dim3, 3)
     numerator = tf.reduce_sum(masked_grid, axis=[1, 2, 3])  # (batch, 3)
     denominator = tf.reduce_sum(bool_mask, axis=[1, 2, 3])  # (batch, 1)
-    return numerator / (denominator + EPS)  # (batch, 3)
+    return (numerator + EPS) / (denominator + EPS)  # (batch, 3)
 
 
 def compute_centroid_distance(

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ pytest
 pytest-cov
 pytest-dependency
 pyyaml>=5.3.1
+scipy
 seed-isort-config
 sphinx==3.2.1
 sphinx-notfound-page

--- a/test/unit/test_loss_image.py
+++ b/test/unit/test_loss_image.py
@@ -94,4 +94,4 @@ def test_gmi(y_true, y_pred, expected):
     TODO when y_true == y_pred, the return is not exactly zero
     """
     got = image.global_mutual_information(y_true=y_true, y_pred=y_pred)
-    assert is_equal_tf(got, expected, atol=1.0e-6)
+    assert is_equal_tf(got, expected, atol=1.0e-5)

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -252,7 +252,7 @@ def test_compute_centroid():
     tensor_grid[:, :, :, 2] *= 3
     tensor_grid = tf.constant(tensor_grid, dtype=tf.float32)
 
-    expected = np.ones((3, 3))  # use 1 because 0/0 ~= (0+eps)/(0+eps) = 1
+    expected = np.zeros((3, 3))  # use 1 because 0/0 ~= 0/(0+eps) = 0
     expected[0, :] = [1, 2, 3]
     got = label.compute_centroid(tensor_mask, tensor_grid)
     assert is_equal_tf(got, expected)

--- a/test/unit/test_loss_label.py
+++ b/test/unit/test_loss_label.py
@@ -252,7 +252,7 @@ def test_compute_centroid():
     tensor_grid[:, :, :, 2] *= 3
     tensor_grid = tf.constant(tensor_grid, dtype=tf.float32)
 
-    expected = np.zeros((3, 3))  # use 1 because 0/0 ~= 0/(0+eps) = 0
+    expected = np.ones((3, 3))  # use 1 because 0/0 ~= (0+eps)/(0+eps) = 1
     expected[0, :] = [1, 2, 3]
     got = label.compute_centroid(tensor_mask, tensor_grid)
     assert is_equal_tf(got, expected)


### PR DESCRIPTION
# Description

The reason for the bug was related to `tf.math.div_no_nan` which returns 0 when we do division by 0, but the gradient for this might not be well defined and it causes some layers to have non-numeric weights (nan/inf).

Therefore the solution is to add a machine epsilon to both numerator and denominator for the division. Here, instead of defining it manually, we use `tf.keras.backend.epsilon()` which is actually `1e-7` because the machine epsilon for float32 is smaller than 1e-7 but bigger than 1e-8.

```
>>> import numpy as np
>>> np.finfo(np.float32).eps
1.1920929e-07
>>> np.finfo(np.float16).eps
0.000977
```

Fixes #452 

## Type of change

What types of changes does your code introduce to DeepReg? _Put an `x` in the boxes that
apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation Update (fix or improvement on the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask. We're here to help! This is
simply a reminder of what we are going to look for before merging your code._

- [x] I have
      [installed pre-commit](https://deepreg.readthedocs.io/en/latest/contributing/setup.html)
      and formatted all changed files.
- [x] My commits' message styles matches
      [our requested structure](https://deepreg.readthedocs.io/en/latest/contributing/commit.html),
      e.g. `Issue #<issue number>: detailed message`.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
