### PR TITLE
533 wrong bias init in globalnet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed build error when downloading data from private repo
+- Fixed bias initialization for theta in GlobalNet.
+- Fixed build error when downloading data from private repo.
 
 ## [0.1.0] - 2020-11-02
 

--- a/deepreg/model/backbone/global_net.py
+++ b/deepreg/model/backbone/global_net.py
@@ -2,6 +2,7 @@
 
 from typing import List
 
+import numpy as np
 import tensorflow as tf
 
 from deepreg.model import layer, layer_util
@@ -48,7 +49,7 @@ class GlobalNet(tf.keras.Model):
         self._extract_max_level = max(self._extract_levels)  # E
         self.reference_grid = layer_util.get_reference_grid(image_size)
         self.transform_initial = tf.constant_initializer(
-            value=[1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]
+            value=list(np.eye(4, 3).reshape((-1)))
         )
         # init layer variables
         num_channels = [

--- a/test/unit/test_backbone.py
+++ b/test/unit/test_backbone.py
@@ -18,7 +18,7 @@ def test_init_GlobalNet():
     """
     Testing init of GlobalNet is built as expected.
     """
-    # Initialising GlobalNet instance
+    # initialising GlobalNet instance
     global_test = g.GlobalNet(
         image_size=[1, 2, 3],
         out_channels=3,
@@ -28,9 +28,9 @@ def test_init_GlobalNet():
         out_activation="softmax",
     )
 
-    # Asserting initialised var for extract_levels is the same - Pass
+    # asserting initialised var for extract_levels is the same - Pass
     assert global_test._extract_levels == [1, 2, 3]
-    # Asserting initialised var for extract_max_level is the same - Pass
+    # asserting initialised var for extract_max_level is the same - Pass
     assert global_test._extract_max_level == 3
 
     # self reference grid
@@ -48,18 +48,26 @@ def test_init_GlobalNet():
     )
     assert is_equal_tf(global_test.reference_grid, expected_ref_grid)
 
-    # Assert downsample blocks type is correct, Pass
+    # assert correct initial transform is returned
+    expected_transform_initial = tf.convert_to_tensor(
+        [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        dtype=tf.float32,
+    )
+    global_transform_initial = tf.Variable(global_test.transform_initial(shape=[12]))
+    assert is_equal_tf(global_transform_initial, expected_transform_initial)
+
+    # assert downsample blocks type is correct, Pass
     assert all(
         isinstance(item, layer.DownSampleResnetBlock)
         for item in global_test._downsample_blocks
     )
-    # Assert number of downsample blocks is correct (== max level), Pass
+    # assert number of downsample blocks is correct (== max level), Pass
     assert len(global_test._downsample_blocks) == 3
 
-    #  Assert conv3dBlock type is correct, Pass
+    # assert conv3dBlock type is correct, Pass
     assert isinstance(global_test._conv3d_block, layer.Conv3dBlock)
 
-    #  Asserting type is dense_layer, Pass
+    # asserting type is dense_layer, Pass
     assert isinstance(global_test._dense_layer, layer.Dense)
 
 
@@ -70,7 +78,7 @@ def test_call_GlobalNet():
     """
     out = 3
     im_size = [1, 2, 3]
-    # Initialising GlobalNet instance
+    # initialising GlobalNet instance
     global_test = g.GlobalNet(
         image_size=im_size,
         out_channels=out,
@@ -79,17 +87,17 @@ def test_call_GlobalNet():
         out_kernel_initializer="softmax",
         out_activation="softmax",
     )
-    # Pass an input of all zeros
+    # pass an input of all zeros
     inputs = tf.constant(
         np.zeros((5, im_size[0], im_size[1], im_size[2], out), dtype=np.float32)
     )
-    # Get outputs by calling
+    # get outputs by calling
     output = global_test.call(inputs)
-    # Expected shape is (5, 1, 2, 3, 3)
+    # expected shape is (5, 1, 2, 3, 3)
     assert all(x == y for x, y in zip(inputs.shape, output.shape))
 
 
-# Testing LocalNet
+# testing LocalNet
 def test_init_LocalNet():
     """
     Testing init of LocalNet as expected
@@ -103,34 +111,34 @@ def test_init_LocalNet():
         out_activation="softmax",
     )
 
-    # Asserting initialised var for extract_levels is the same - Pass
+    # asserting initialised var for extract_levels is the same - Pass
     assert local_test._extract_levels == [1, 2, 3]
-    # Asserting initialised var for extract_max_level is the same - Pass
+    # asserting initialised var for extract_max_level is the same - Pass
     assert local_test._extract_max_level == 3
-    # Asserting initialised var for extract_min_level is the same - Pass
+    # asserting initialised var for extract_min_level is the same - Pass
     assert local_test._extract_min_level == 1
 
-    # Assert downsample blocks type is correct, Pass
+    # assert downsample blocks type is correct, Pass
     assert all(
         isinstance(item, layer.DownSampleResnetBlock)
         for item in local_test._downsample_blocks
     )
-    # Assert number of downsample blocks is correct (== max level), Pass
+    # assert number of downsample blocks is correct (== max level), Pass
     assert len(local_test._downsample_blocks) == 3
 
-    # Assert upsample blocks type is correct, Pass
+    # assert upsample blocks type is correct, Pass
     assert all(
         isinstance(item, layer.LocalNetUpSampleResnetBlock)
         for item in local_test._upsample_blocks
     )
-    # Assert number of upsample blocks is correct (== max level - min level), Pass
+    # assert number of upsample blocks is correct (== max level - min level), Pass
     assert len(local_test._upsample_blocks) == 3 - 1
 
-    # Assert upsample blocks type is correct, Pass
+    # assert upsample blocks type is correct, Pass
     assert all(
         isinstance(item, layer.Conv3dWithResize) for item in local_test._extract_layers
     )
-    # Assert number of upsample blocks is correct (== extract_levels), Pass
+    # assert number of upsample blocks is correct (== extract_levels), Pass
     assert len(local_test._extract_layers) == 3
 
 
@@ -141,7 +149,7 @@ def test_call_LocalNet():
     """
     out = 3
     im_size = [1, 2, 3]
-    # Initialising LocalNet instance
+    # initialising LocalNet instance
     global_test = loc.LocalNet(
         image_size=im_size,
         out_channels=out,
@@ -150,17 +158,17 @@ def test_call_LocalNet():
         out_kernel_initializer="glorot_uniform",
         out_activation="sigmoid",
     )
-    # Pass an input of all zeros
+    # pass an input of all zeros
     inputs = tf.constant(
         np.zeros((5, im_size[0], im_size[1], im_size[2], out), dtype=np.float32)
     )
-    # Get outputs by calling
+    # get outputs by calling
     output = global_test.call(inputs)
-    # Expected shape is (5, 1, 2, 3, 3)
+    # expected shape is (5, 1, 2, 3, 3)
     assert all(x == y for x, y in zip(inputs.shape, output.shape))
 
 
-# Testing UNet
+# testing UNet
 def test_init_UNet():
     """
     Testing init of UNet as expected
@@ -174,34 +182,34 @@ def test_init_UNet():
         out_activation="softmax",
     )
 
-    # Asserting num channels initial is the same, Pass
+    # asserting num channels initial is the same, Pass
     assert local_test._num_channel_initial == 3
 
-    # Asserting depth is the same, Pass
+    # asserting depth is the same, Pass
     assert local_test._depth == 5
 
-    # Assert downsample blocks type is correct, Pass
+    # assert downsample blocks type is correct, Pass
     assert all(
         isinstance(item, layer.DownSampleResnetBlock)
         for item in local_test._downsample_blocks
     )
-    # Assert number of downsample blocks is correct (== depth), Pass
+    # assert number of downsample blocks is correct (== depth), Pass
     assert len(local_test._downsample_blocks) == 5
 
-    #  Assert bottom_conv3d type is correct, Pass
+    # assert bottom_conv3d type is correct, Pass
     assert isinstance(local_test._bottom_conv3d, layer.Conv3dBlock)
 
-    # Assert bottom res3d type is correct, Pass
+    # assert bottom res3d type is correct, Pass
     assert isinstance(local_test._bottom_res3d, layer.Residual3dBlock)
-    # Assert upsample blocks type is correct, Pass
+    # assert upsample blocks type is correct, Pass
     assert all(
         isinstance(item, layer.UpSampleResnetBlock)
         for item in local_test._upsample_blocks
     )
-    # Assert number of upsample blocks is correct (== depth), Pass
+    # assert number of upsample blocks is correct (== depth), Pass
     assert len(local_test._upsample_blocks) == 5
 
-    # Assert output_conv3d is correct type, Pass
+    # assert output_conv3d is correct type, Pass
     assert isinstance(local_test._output_conv3d, layer.Conv3dWithResize)
 
 
@@ -212,7 +220,7 @@ def test_call_UNet():
     """
     out = 3
     im_size = [1, 2, 3]
-    # Initialising LocalNet instance
+    # initialising LocalNet instance
     global_test = u.UNet(
         image_size=im_size,
         out_channels=out,
@@ -221,11 +229,11 @@ def test_call_UNet():
         out_kernel_initializer="glorot_uniform",
         out_activation="sigmoid",
     )
-    # Pass an input of all zeros
+    # pass an input of all zeros
     inputs = tf.constant(
         np.zeros((5, im_size[0], im_size[1], im_size[2], out), dtype=np.float32)
     )
-    # Get outputs by calling
+    # get outputs by calling
     output = global_test.call(inputs)
-    # Expected shape is (5, 1, 2, 3)
+    # expected shape is (5, 1, 2, 3)
     assert all(x == y for x, y in zip(inputs.shape, output.shape))

--- a/test/unit/test_backbone.py
+++ b/test/unit/test_backbone.py
@@ -48,22 +48,6 @@ def test_init_GlobalNet():
     )
     assert is_equal_tf(global_test.reference_grid, expected_ref_grid)
 
-    # Testing constant initializer
-    # We initialize the expected tensor and initialise another from the
-    # class variable using tf.Variable
-    test_tensor_return = tf.convert_to_tensor(
-        [[1.0, 0.0], [0.0, 0.0], [0.0, 1.0], [0.0, 0.0], [0.0, 0.0], [1.0, 0.0]],
-        dtype=tf.float32,
-    )
-    global_return = tf.Variable(
-        global_test.transform_initial(shape=[6, 2], dtype=tf.float32)
-    )
-
-    # Asserting they are equal - Pass
-    assert is_equal_tf(
-        test_tensor_return, tf.convert_to_tensor(global_return, dtype=tf.float32)
-    )
-
     # Assert downsample blocks type is correct, Pass
     assert all(
         isinstance(item, layer.DownSampleResnetBlock)

--- a/test/unit/test_layer_util.py
+++ b/test/unit/test_layer_util.py
@@ -217,45 +217,54 @@ def test_random_transform_generator():
     assert is_equal_tf(got, expected)
 
 
-def test_warp_grid():
+class TestWarpGrid:
     """
     Test warp_grid by confirming that it generates
-    appropriate solutions for a simple precomputed case.
+    appropriate solutions for simple precomputed cases.
     """
+
     grid = tf.constant(
         np.array(
             [[[[0, 0, 0], [0, 0, 1], [0, 0, 2]], [[0, 1, 0], [0, 1, 1], [0, 1, 2]]]],
             dtype=np.float32,
         )
     )  # shape = (1, 2, 3, 3)
-    theta = tf.constant(
-        np.array(
-            [
-                [
-                    [0.86, 0.75, 0.48],
-                    [0.07, 0.98, 0.01],
-                    [0.72, 0.52, 0.97],
-                    [0.12, 0.4, 0.04],
-                ]
-            ],
-            dtype=np.float32,
-        )
-    )  # shape = (1, 4, 3)
-    expected = tf.constant(
-        np.array(
-            [
+
+    def test_identical(self):
+        theta = tf.constant(np.eye(4, 3).reshape((1, 4, 3)), dtype=tf.float32)
+        expected = self.grid[None, ...]  # shape = (1, 1, 2, 3, 3)
+        got = layer_util.warp_grid(grid=self.grid, theta=theta)
+        assert is_equal_tf(got, expected)
+
+    def test_non_identical(self):
+        theta = tf.constant(
+            np.array(
                 [
                     [
-                        [[0.12, 0.4, 0.04], [0.84, 0.92, 1.01], [1.56, 1.44, 1.98]],
-                        [[0.19, 1.38, 0.05], [0.91, 1.9, 1.02], [1.63, 2.42, 1.99]],
+                        [0.86, 0.75, 0.48],
+                        [0.07, 0.98, 0.01],
+                        [0.72, 0.52, 0.97],
+                        [0.12, 0.4, 0.04],
                     ]
-                ]
-            ],
-            dtype=np.float32,
-        )
-    )  # shape = (1, 1, 2, 3, 3)
-    got = layer_util.warp_grid(grid=grid, theta=theta)
-    assert is_equal_tf(got, expected)
+                ],
+                dtype=np.float32,
+            )
+        )  # shape = (1, 4, 3)
+        expected = tf.constant(
+            np.array(
+                [
+                    [
+                        [
+                            [[0.12, 0.4, 0.04], [0.84, 0.92, 1.01], [1.56, 1.44, 1.98]],
+                            [[0.19, 1.38, 0.05], [0.91, 1.9, 1.02], [1.63, 2.42, 1.99]],
+                        ]
+                    ]
+                ],
+                dtype=np.float32,
+            )
+        )  # shape = (1, 1, 2, 3, 3)
+        got = layer_util.warp_grid(grid=self.grid, theta=theta)
+        assert is_equal_tf(got, expected)
 
 
 def test_warp_image_ddf():


### PR DESCRIPTION
# Description

Fixes #533

Would be better to take the chance to refact global net related tests.

## Type of change

What types of changes does your code introduce to DeepReg? _Put an `x` in the boxes that
apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation Update (fix or improvement on the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR.
If you're unsure about any of them, don't hesitate to ask. We're here to help! This is
simply a reminder of what we are going to look for before merging your code._

- [x] I have
      [installed pre-commit](https://deepreg.readthedocs.io/en/latest/contributing/setup.html)
      using `pre-commit install` and formatted all changed files. If you are not
      certain, run `pre-commit run --all-files`.
- [x] My commits' message styles matches
      [our requested structure](https://deepreg.readthedocs.io/en/latest/contributing/commit.html),
      e.g. `Issue #<issue number>: detailed message`.
- [ ] I have updated the
      [change log file](https://github.com/DeepRegNet/DeepReg/blob/main/CHANGELOG.md)
      regarding my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
