### PR TITLE
Issue #615: add zero boundary option to resampler and set as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed warp CLI tool by saving outputs in Nifti1 format.
 - Fixed optimiser storage and loading from checkpoints.
 - Fixed bias initialization for theta in GlobalNet.
 - Removed invalid `first` argument in DataLoader for sample_index generator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Modified the implementation of resampler to support zero boundary condition.
 - Refactored loss functions into classes.
 - Use CheckpointManager callback for saving and support training restore.
 - Changed distribute strategy to default for <= 1 GPU.

--- a/deepreg/model/layer_util.py
+++ b/deepreg/model/layer_util.py
@@ -116,37 +116,38 @@ def pyramid_combination(
 
     The weights correspond to the floor corners.
     For example, when num_dimension = len(loc_shape) = num_bits = 3,
-    weight_floor = [w1, w2, w3] (ignoring the batch dimension).
-    weight_ceil = [u1, u2, u3] (ignoring the batch dimension).
+    weight_floor = [f1, f2, f3] (ignoring the batch dimension).
+    weight_ceil = [c1, c2, c3] (ignoring the batch dimension).
 
     So for corner with coords (x, y, z), x, y, z's values are 0 or 1
 
-    - weight for x = w1 if x = 0 else u1
-    - weight for y = w2 if y = 0 else u2
-    - weight for z = w3 if z = 0 else u3
+    - weight for x = f1 if x = 0 else c1
+    - weight for y = f2 if y = 0 else c2
+    - weight for z = f3 if z = 0 else c3
 
     so the weight for (x, y, z) is
 
-    W_xyz = ((1-x) * w1 + x * u1)
-          * ((1-y) * w2 + y * u2)
-          * ((1-z) * w3 + z * u3)
+    W_xyz = ((1-x) * f1 + x * c1)
+          * ((1-y) * f2 + y * c2)
+          * ((1-z) * f3 + z * c3)
 
     Let
 
-    W_xy = ((1-x) * w1 + x * u1)
-         * ((1-y) * w2 + y * u2)
+    W_xy = ((1-x) * f1 + x * c1)
+         * ((1-y) * f2 + y * c2)
 
     Then
 
-    - W_xy0 = W_xy * w3
-    - W_xy1 = W_xy * u3
+    - W_xy0 = W_xy * f3
+    - W_xy1 = W_xy * c3
 
-    So, the final sum V equals
+    Similar to W_xyz, denote V_xyz the value at (x, y, z),
+    the final sum V equals
 
       sum over x,y,z (V_xyz * W_xyz)
-      = sum over x,y (V_xy0 * W_xy0 + V_xy1 * W_xy1)
-      = sum over x,y (V_xy0 * W_xy * w3 + V_xy1 * W_xy * u3)
-      = sum over x,y (V_xy0 * W_xy) * w3 + sum over x,y (V_xy1 * W_xy) * u3
+    = sum over x,y (V_xy0 * W_xy0 + V_xy1 * W_xy1)
+    = sum over x,y (V_xy0 * W_xy * f3 + V_xy1 * W_xy * c3)
+    = sum over x,y (V_xy0 * W_xy) * f3 + sum over x,y (V_xy1 * W_xy) * c3
 
     That's why we call this pyramid combination.
     It calculates the linear interpolation gradually, starting from
@@ -168,10 +169,12 @@ def pyramid_combination(
     :return: one tensor of the same shape as an element in values
              (\*loc_shape) or (batch, \*loc_shape) or (batch, \*loc_shape, 1)
     """
-    if len(values[0].shape) != len(weight_floor[0].shape):
+    if len(values[0].shape) != len(weight_floor[0].shape) or len(
+        values[0].shape
+    ) != len(weight_ceil[0].shape):
         raise ValueError(
-            "In pyramid_combination, "
-            "elements of values and weight_floor should have same dimension. "
+            "In pyramid_combination, elements of "
+            "values, weight_floor, and weight_ceil should have same dimension. "
             f"value shape = {values[0].shape}, "
             f"weight_floor = {weight_floor[0].shape}"
         )

--- a/deepreg/model/layer_util.py
+++ b/deepreg/model/layer_util.py
@@ -116,36 +116,37 @@ def pyramid_combination(
 
     The weights correspond to the floor corners.
     For example, when num_dimension = len(loc_shape) = num_bits = 3,
-    weights = [w1, w2, w3] (ignoring the batch dimension).
+    weight_floor = [w1, w2, w3] (ignoring the batch dimension).
+    weight_ceil = [u1, u2, u3] (ignoring the batch dimension).
 
     So for corner with coords (x, y, z), x, y, z's values are 0 or 1
 
-    - weight for x = w1 if x = 0 else 1-w1
-    - weight for y = w2 if y = 0 else 1-w2
-    - weight for z = w3 if z = 0 else 1-w3
+    - weight for x = w1 if x = 0 else u1
+    - weight for y = w2 if y = 0 else u2
+    - weight for z = w3 if z = 0 else u3
 
     so the weight for (x, y, z) is
 
-    W_xyz = ((1-x) * w1 + x * (1-w1))
-    * ((1-y) * w2 + y * (1-w2))
-    * ((1-z) * w3 + z * (1-w3))
+    W_xyz = ((1-x) * w1 + x * u1)
+          * ((1-y) * w2 + y * u2)
+          * ((1-z) * w3 + z * u3)
 
-     = (W_xy * (1-z)) * w3 + (W_xy * z) * (1-w3)
+    Let
 
-    where W_xy is the weight for (x, y), let
+    W_xy = ((1-x) * w1 + x * u1)
+         * ((1-y) * w2 + y * u2)
+
+    Then
 
     - W_xy0 = W_xy * w3
-    - W_xy1 = W_xy * (1-w3)
+    - W_xy1 = W_xy * u3
 
     So, the final sum V equals
 
       sum over x,y,z (V_xyz * W_xyz)
-
-      = sum over x,y ( V_xy0 * W_xy0 + V_xy1 * W_xy1 )
-
-      = sum over x,y ( V_xy0 * W_xy * w3 + V_xy1 * W_xy * (1-w3) )
-
-      = sum over x,y ( W_xy * (V_xy0 * w3 + V_xy1 * W_xy * (1-w3)) )
+      = sum over x,y (V_xy0 * W_xy0 + V_xy1 * W_xy1)
+      = sum over x,y (V_xy0 * W_xy * w3 + V_xy1 * W_xy * u3)
+      = sum over x,y (V_xy0 * W_xy) * w3 + sum over x,y (V_xy1 * W_xy) * u3
 
     That's why we call this pyramid combination.
     It calculates the linear interpolation gradually, starting from

--- a/deepreg/model/layer_util.py
+++ b/deepreg/model/layer_util.py
@@ -169,42 +169,41 @@ def pyramid_combination(
     :return: one tensor of the same shape as an element in values
              (\*loc_shape) or (batch, \*loc_shape) or (batch, \*loc_shape, 1)
     """
-    if len(values[0].shape) != len(weight_floor[0].shape) or len(
-        values[0].shape
-    ) != len(weight_ceil[0].shape):
+    v_shape = values[0].shape
+    wf_shape = weight_floor[0].shape
+    wc_shape = weight_ceil[0].shape
+    if len(v_shape) != len(wf_shape) or len(v_shape) != len(wc_shape):
         raise ValueError(
             "In pyramid_combination, elements of "
             "values, weight_floor, and weight_ceil should have same dimension. "
-            f"value shape = {values[0].shape}, "
-            f"weight_floor = {weight_floor[0].shape}"
+            f"value shape = {v_shape}, "
+            f"weight_floor = {wf_shape}, "
+            f"weight_ceil = {wc_shape}."
         )
     if 2 ** len(weight_floor) != len(values):
         raise ValueError(
             "In pyramid_combination, "
             "num_dim = len(weight_floor), "
             "len(values) must be 2 ** num_dim, "
-            f"But len(weight_floor) = {len(weight_floor)}, len(values) = {len(values)}"
+            f"But len(weight_floor) = {len(weight_floor)}, "
+            f"len(values) = {len(values)}"
         )
 
     if len(weight_floor) == 1:  # one dimension
         return values[0] * weight_floor[0] + values[1] * weight_ceil[0]
     # multi dimension
-    values_floor = (
-        pyramid_combination(
-            values=values[::2],
-            weight_floor=weight_floor[:-1],
-            weight_ceil=weight_ceil[:-1],
-        )
-        * weight_floor[-1]
+    values_floor = pyramid_combination(
+        values=values[::2],
+        weight_floor=weight_floor[:-1],
+        weight_ceil=weight_ceil[:-1],
     )
-    values_ceil = (
-        pyramid_combination(
-            values=values[1::2],
-            weight_floor=weight_floor[:-1],
-            weight_ceil=weight_ceil[:-1],
-        )
-        * weight_ceil[-1]
+    values_floor = values_floor * weight_floor[-1]
+    values_ceil = pyramid_combination(
+        values=values[1::2],
+        weight_floor=weight_floor[:-1],
+        weight_ceil=weight_ceil[:-1],
     )
+    values_ceil = values_ceil * weight_ceil[-1]
     return values_floor + values_ceil
 
 
@@ -451,7 +450,7 @@ def gen_rand_affine_transform(
     """
 
     assert 0 <= scale <= 1
-    np.random.seed(seed=seed)
+    np.random.seed(seed)
     noise = np.random.uniform(1 - scale, 1, [batch_size, 4, 3])  # shape = (batch, 4, 3)
 
     # old represents four corners of a cube
@@ -488,7 +487,7 @@ def gen_rand_ddf(
     :return:
     """
 
-    np.random.seed(seed=seed)
+    np.random.seed(seed)
     low_res_strength = np.random.uniform(0, field_strength, (batch_size, 1, 1, 1, 3))
     low_res_field = low_res_strength * np.random.randn(
         batch_size, low_res_size[0], low_res_size[1], low_res_size[2], 3

--- a/deepreg/warp.py
+++ b/deepreg/warp.py
@@ -59,7 +59,7 @@ def warp(image_path: str, ddf_path: str, out_path: str):
     warped_image = warped_image[0, ...]  # removed added batch dimension
 
     # save output
-    nib.save(img=nib.Nifti2Image(warped_image, affine=np.eye(4)), filename=out_path)
+    nib.save(img=nib.Nifti1Image(warped_image, affine=np.eye(4)), filename=out_path)
 
 
 def main(args=None):

--- a/test/unit/test_layer_util.py
+++ b/test/unit/test_layer_util.py
@@ -92,9 +92,8 @@ class TestPyramidCombination:
                 values=values, weight_floor=weights, weight_ceil=1 - weights
             )
         assert (
-            "In pyramid_combination, "
-            "elements of values and weight_floor should have same dimension"
-            in str(err_info.value)
+            "In pyramid_combination, elements of values, weight_floor, "
+            "and weight_ceil should have same dimension" in str(err_info.value)
         )
 
     def test_error_len(self):

--- a/test/unit/test_layer_util.py
+++ b/test/unit/test_layer_util.py
@@ -49,140 +49,134 @@ def test_get_n_bits_combinations():
     ]
 
 
-def test_pyramid_combinations():
-    """
-    Test pyramid_combinations by confirming that it generates
-    appropriate solutions for simple 1D and 2D cases.
-    """
-    # Check numerical outputs are correct for a simple 1D pair of weights, values - Pass
-    weights = tf.constant(np.array([[0.2]], dtype=np.float32))
-    values = tf.constant(np.array([[1], [2]], dtype=np.float32))
-    # expected = 1 * 0.2 + 2 * 2
-    expected = tf.constant(np.array([1.8], dtype=np.float32))
-    got = layer_util.pyramid_combination(values=values, weights=weights)
-    assert is_equal_tf(got, expected)
+class TestPyramidCombination:
+    def test_1d(self):
+        weights = tf.constant(np.array([[0.2]], dtype=np.float32))
+        values = tf.constant(np.array([[1], [2]], dtype=np.float32))
 
-    # Check numerical outputs are correct for a 2D pair of weights, values - Pass
-    weights = tf.constant(np.array([[0.2], [0.3]], dtype=np.float32))
-    values = tf.constant(
-        np.array(
-            [
-                [1],  # value at corner (0, 0), weight = 0.2 * 0.3
-                [2],  # value at corner (0, 1), weight = 0.2 * 0.7
-                [3],  # value at corner (1, 0), weight = 0.8 * 0.3
-                [4],  # value at corner (1, 1), weight = 0.8 * 0.7
-            ],
-            dtype=np.float32,
+        # expected = 1 * 0.2 + 2 * 2
+        expected = tf.constant(np.array([1.8], dtype=np.float32))
+        got = layer_util.pyramid_combination(
+            values=values, weight_floor=weights, weight_ceil=1 - weights
         )
-    )
-    # expected = 1 * 0.2 * 0.3
-    #          + 2 * 0.2 * 0.7
-    #          + 3 * 0.8 * 0.3
-    #          + 4 * 0.8 * 0.7
-    expected = tf.constant(np.array([3.3], dtype=np.float32))
-    got = layer_util.pyramid_combination(values=values, weights=weights)
-    assert is_equal_tf(got, expected)
+        assert is_equal_tf(got, expected)
 
-    # Check input lengths match - Fail
-    weights = tf.constant(np.array([[[0.2]], [[0.2]]], dtype=np.float32))
-    values = tf.constant(np.array([[1], [2]], dtype=np.float32))
-    with pytest.raises(ValueError) as err_info:
-        layer_util.pyramid_combination(values=values, weights=weights)
-    assert (
-        "In pyramid_combination, "
-        "elements of values and weights should have same dimension"
-        in str(err_info.value)
-    )
+    def test_2d(self):
+        weights = tf.constant(np.array([[0.2], [0.3]], dtype=np.float32))
+        values = tf.constant(
+            np.array(
+                [
+                    [1],  # value at corner (0, 0), weight = 0.2 * 0.3
+                    [2],  # value at corner (0, 1), weight = 0.2 * 0.7
+                    [3],  # value at corner (1, 0), weight = 0.8 * 0.3
+                    [4],  # value at corner (1, 1), weight = 0.8 * 0.7
+                ],
+                dtype=np.float32,
+            )
+        )
+        # expected = 1 * 0.2 * 0.3
+        #          + 2 * 0.2 * 0.7
+        #          + 3 * 0.8 * 0.3
+        #          + 4 * 0.8 * 0.7
+        expected = tf.constant(np.array([3.3], dtype=np.float32))
+        got = layer_util.pyramid_combination(
+            values=values, weight_floor=weights, weight_ceil=1 - weights
+        )
+        assert is_equal_tf(got, expected)
 
-    # Check input lengths match - Fail
-    weights = tf.constant(np.array([[0.2]], dtype=np.float32))
-    values = tf.constant(np.array([[1]], dtype=np.float32))
-    with pytest.raises(ValueError) as err_info:
-        layer_util.pyramid_combination(values=values, weights=weights)
-    assert (
-        "In pyramid_combination, num_dim = len(weights), "
-        "len(values) must be 2 ** num_dim" in str(err_info.value)
-    )
+    def test_error_dim(self):
+        weights = tf.constant(np.array([[[0.2]], [[0.2]]], dtype=np.float32))
+        values = tf.constant(np.array([[1], [2]], dtype=np.float32))
+        with pytest.raises(ValueError) as err_info:
+            layer_util.pyramid_combination(
+                values=values, weight_floor=weights, weight_ceil=1 - weights
+            )
+        assert (
+            "In pyramid_combination, "
+            "elements of values and weight_floor should have same dimension"
+            in str(err_info.value)
+        )
+
+    def test_error_len(self):
+        weights = tf.constant(np.array([[0.2]], dtype=np.float32))
+        values = tf.constant(np.array([[1]], dtype=np.float32))
+        with pytest.raises(ValueError) as err_info:
+            layer_util.pyramid_combination(
+                values=values, weight_floor=weights, weight_ceil=1 - weights
+            )
+        assert (
+            "In pyramid_combination, num_dim = len(weight_floor), "
+            "len(values) must be 2 ** num_dim" in str(err_info.value)
+        )
 
 
-def test_resample():
-    """
-    Test resample by confirming that it generates appropriate
-    resampling on two test cases with outputs within is_equal_tf's
-    tolerance level, and one which should fail (incompatible shapes).
-    """
-    # linear, vol has no feature channel - Pass
-    interpolation = "linear"
-    vol = tf.constant(
-        np.array([[[0, 1, 2], [3, 4, 5]]], dtype=np.float32)
-    )  # shape = [1,2,3]
+class TestLinearResample:
+    # vol are values on grid [0,1]x[0,2]
+    # values on each point is 3x+y
+    # shape = (1,2,3)
+    vol = tf.constant(np.array([[[0, 1, 2], [3, 4, 5]]]), dtype=tf.float32)
+    # loc are some points, especially
+    # shape = (1,4,3,2)
     loc = tf.constant(
         np.array(
             [
                 [
-                    [[0, 0], [0, 1], [0, 3]],  # outside frame
-                    [[0.4, 0], [0.5, 1], [0.6, 2]],
-                    [[0.4, 0.7], [0.5, 0.5], [0.6, 0.3]],
+                    [[0, 0], [0, 1], [1, 2]],  # boundary corners
+                    [[0.4, 0], [0.5, 2], [0.6, 2]],  # boundary edge
+                    [[-0.4, 0.7], [0, 3], [2, 2]],  # outside boundary
+                    [[0.4, 0.7], [0.5, 0.5], [0.6, 0.3]],  # internal
                 ]
-            ],  # resampled = 3x+y
-            dtype=np.float32,
-        )
-    )  # shape = [1,3,3,2]
-    want = tf.constant(
-        np.array([[[0, 1, 2], [1.2, 2.5, 3.8], [1.9, 2, 2.1]]], dtype=np.float32)
-    )  # shape = [1,3,3]
-    get = layer_util.resample(vol=vol, loc=loc, interpolation=interpolation)
-    assert is_equal_tf(want, get)
+            ]
+        ),
+        dtype=tf.float32,
+    )
 
-    # linear, vol has feature channel - Pass
-    interpolation = "linear"
-    vol = tf.constant(
-        np.array(
-            [[[[0, 0], [1, 1], [2, 2]], [[3, 3], [4, 4], [5, 5]]]], dtype=np.float32
-        )
-    )  # shape = [1,2,3,2]
-    loc = tf.constant(
-        np.array(
-            [
-                [
-                    [[0, 0], [0, 1], [0, 3]],  # outside frame
-                    [[0.4, 0], [0.5, 1], [0.6, 2]],
-                    [[0.4, 0.7], [0.5, 0.5], [0.6, 0.3]],
-                ]
-            ],  # resampled = 3x+y
-            dtype=np.float32,
-        )
-    )  # shape = [1,3,3,2]
-    want = tf.constant(
-        np.array(
-            [
-                [
-                    [[0, 0], [1, 1], [2, 2]],
-                    [[1.2, 1.2], [2.5, 2.5], [3.8, 3.8]],
-                    [[1.9, 1.9], [2, 2], [2.1, 2.1]],
-                ]
-            ],
-            dtype=np.float32,
-        )
-    )  # shape = [1,3,3,2]
-    get = layer_util.resample(vol=vol, loc=loc, interpolation=interpolation)
-    assert is_equal_tf(want, get)
+    @pytest.mark.parametrize("channel", [0, 1, 2])
+    def test_repeat_extrapolation(self, channel):
+        x = self.loc[..., 0]
+        y = self.loc[..., 1]
+        x = tf.clip_by_value(x, 0, 1)
+        y = tf.clip_by_value(y, 0, 2)
+        expected = 3 * x + y
 
-    # Inconsistent shapes for resampling - Fail
-    interpolation = "linear"
-    vol = tf.constant(np.array([[0]], dtype=np.float32))  # shape = [1,1]
-    loc = tf.constant(np.array([[0, 0], [0, 0]], dtype=np.float32))  # shape = [2,2]
-    with pytest.raises(ValueError) as err_info:
-        layer_util.resample(vol=vol, loc=loc, interpolation=interpolation)
-    assert "vol shape inconsistent with loc" in str(err_info.value)
+        vol = self.vol
+        if channel > 0:
+            vol = tf.repeat(vol[..., None], channel, axis=-1)
+            expected = tf.repeat(expected[..., None], channel, axis=-1)
 
-    # Non-'linear' resampling - Fail
-    interpolation = "some-string"
-    vol = tf.constant(np.array([[0]], dtype=np.float32))  # shape = [1,1]
-    loc = tf.constant(np.array([[0, 0], [0, 0]], dtype=np.float32))  # shape = [2,2]
-    with pytest.raises(ValueError) as err_info:
-        layer_util.resample(vol=vol, loc=loc, interpolation=interpolation)
-    assert "resample supports only linear interpolation" in str(err_info.value)
+        got = layer_util.resample(vol=vol, loc=self.loc, zero_boundary=False)
+        assert is_equal_tf(expected, got)
+
+    @pytest.mark.parametrize("channel", [0, 1, 2])
+    def test_repeat_zero_bound(self, channel):
+        x = self.loc[..., 0]
+        y = self.loc[..., 1]
+        expected = 3 * x + y
+        expected = expected * tf.cast(x > 0, tf.float32) * tf.cast(x < 1, tf.float32)
+        expected = expected * tf.cast(y > 0, tf.float32) * tf.cast(y < 2, tf.float32)
+
+        vol = self.vol
+        if channel > 0:
+            vol = tf.repeat(vol[..., None], channel, axis=-1)
+            expected = tf.repeat(expected[..., None], channel, axis=-1)
+
+        got = layer_util.resample(vol=vol, loc=self.loc, zero_boundary=True)
+        assert is_equal_tf(expected, got)
+
+    def test_shape_error(self):
+        vol = tf.constant(np.array([[0]], dtype=np.float32))  # shape = [1,1]
+        loc = tf.constant(np.array([[0, 0], [0, 0]], dtype=np.float32))  # shape = [2,2]
+        with pytest.raises(ValueError) as err_info:
+            layer_util.resample(vol=vol, loc=loc)
+        assert "vol shape inconsistent with loc" in str(err_info.value)
+
+    def test_interpolation_error(self):
+        interpolation = "nearest"
+        vol = tf.constant(np.array([[0]], dtype=np.float32))  # shape = [1,1]
+        loc = tf.constant(np.array([[0, 0], [0, 0]], dtype=np.float32))  # shape = [2,2]
+        with pytest.raises(ValueError) as err_info:
+            layer_util.resample(vol=vol, loc=loc, interpolation=interpolation)
+        assert "resample supports only linear interpolation" in str(err_info.value)
 
 
 def test_random_transform_generator():
@@ -417,6 +411,5 @@ class TestGaussianFilter3D:
         [(1, 1, 1), (2, 2, 2), (5, 5, 5)],
     )
     def test_sum(self, kernel_sigma):
-
         filter = layer_util.gaussian_filter_3d(kernel_sigma)
         assert np.allclose(np.sum(filter), 3, atol=1e-3)

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -167,7 +167,7 @@ class TestSaveArray:
         nifti_file_path = os.path.join(self.save_dir, self.arr_name + ".nii.gz")
         # save arr1
         os.makedirs(self.save_dir, exist_ok=True)
-        nib.save(img=nib.Nifti2Image(arr1, affine=np.eye(4)), filename=nifti_file_path)
+        nib.save(img=nib.Nifti1Image(arr1, affine=np.eye(4)), filename=nifti_file_path)
         # save arr2 w/o overwrite
         save_array(
             save_dir=self.save_dir,


### PR DESCRIPTION
# Description

Add zero boundary option to resampler, if the location is on the boundary (corners or edges) the values will be zero.

Fixes #615

## Type of change

What types of changes does your code introduce to DeepReg?

_Please check the boxes that apply after submitting the pull request._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Documentation Update (fix or improvement on the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (if none of the other choices apply)

## Checklist

_Please check the boxes that apply after submitting the pull request._

_If you're unsure about any of them, don't hesitate to ask. We're here to help! This is
simply a reminder of what we are going to look for before merging your code._

- [x] I have
      [installed pre-commit](https://deepreg.readthedocs.io/en/latest/contributing/setup.html)
      using `pre-commit install` and formatted all changed files. If you are not
      certain, run `pre-commit run --all-files`.
- [x] My commits' message styles matches
      [our requested structure](https://deepreg.readthedocs.io/en/latest/contributing/commit.html),
      e.g. `Issue #<issue number>: detailed message`.
- [x] I have updated the
      [change log file](https://github.com/DeepRegNet/DeepReg/blob/main/CHANGELOG.md)
      regarding my changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
