### PR TITLE
Issue #624: fix a typo for label loss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed a bug due to typo when image loss weight is zero, label loss is not applied.
 - Fixed warp CLI tool by saving outputs in Nifti1 format.
 - Fixed optimiser storage and loading from checkpoints.
 - Fixed bias initialization for theta in GlobalNet.

--- a/deepreg/model/network/util.py
+++ b/deepreg/model/network/util.py
@@ -196,7 +196,7 @@ def add_label_loss(
     if fixed_label is None:
         # TODO will refactor the way building models
         return model  # pragma: no cover
-    if loss_config["image"]["weight"] <= 0:
+    if loss_config["label"]["weight"] <= 0:
         # TODO will refactor the way building models
         return model  # pragma: no cover
     config = loss_config["label"].copy()


### PR DESCRIPTION
# Description

Correct typo in the code, which causes not using label loss when image loss is zero.

Fixes #624

## Type of change

What types of changes does your code introduce to DeepReg?

_Please check the boxes that apply after submitting the pull request._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation Update (fix or improvement on the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (if none of the other choices apply)

## Checklist

_Please check the boxes that apply after submitting the pull request._

_If you're unsure about any of them, don't hesitate to ask. We're here to help! This is
simply a reminder of what we are going to look for before merging your code._

- [x] I have
      [installed pre-commit](https://deepreg.readthedocs.io/en/latest/contributing/setup.html)
      using `pre-commit install` and formatted all changed files. If you are not
      certain, run `pre-commit run --all-files`.
- [x] My commits' message styles matches
      [our requested structure](https://deepreg.readthedocs.io/en/latest/contributing/commit.html),
      e.g. `Issue #<issue number>: detailed message`.
- [x] I have updated the
      [change log file](https://github.com/DeepRegNet/DeepReg/blob/main/CHANGELOG.md)
      regarding my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
