### PR TITLE
Multiple loss functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ compatible with the updates.
 
 ### Added
 
-- tba
+- Added support to multiple loss functions for each loss type: "image", "label" and
+  "regularization".
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ compatible with the updates.
 
 - Added support to multiple loss functions for each loss type: "image", "label" and
   "regularization".
+- Added LNCC computation using separable 1-D filters for all kernels available
 
 ### Changed
 

--- a/deepreg/config/parser.py
+++ b/deepreg/config/parser.py
@@ -111,10 +111,15 @@ def config_sanity_check(config: dict) -> dict:
 
     # loss weights should >= 0
     for name in ["image", "label", "regularization"]:
-        loss_weight = config["train"]["loss"][name]["weight"]
-        if loss_weight <= 0:
-            logging.warning(
-                "The %s loss weight %.2f is not positive.", name, loss_weight
-            )
+        loss_config = config["train"]["loss"][name]
+        if not isinstance(loss_config, list):
+            loss_config = [loss_config]
+
+        for loss_i in loss_config:
+            loss_weight = loss_i["weight"]
+            if loss_weight <= 0:
+                logging.warning(
+                    "The %s loss weight %.2f is not positive.", name, loss_weight
+                )
 
     return config

--- a/deepreg/config/v011.py
+++ b/deepreg/config/v011.py
@@ -66,6 +66,10 @@ def parse_image_loss(loss_config: dict) -> dict:
         # no image loss
         return loss_config
 
+    if isinstance(loss_config["image"], list):
+        # config up-to-date
+        return loss_config
+
     image_loss_name = loss_config["image"]["name"]
 
     if image_loss_name not in loss_config["image"]:
@@ -90,6 +94,10 @@ def parse_label_loss(loss_config: dict) -> dict:
     """
     if "label" not in loss_config:
         # no label loss
+        return loss_config
+
+    if isinstance(loss_config["label"], list):
+        # config up-to-date
         return loss_config
 
     label_loss_name = loss_config["label"]["name"]
@@ -125,6 +133,10 @@ def parse_reg_loss(loss_config: dict) -> dict:
     """
     if "regularization" not in loss_config:
         # no regularization loss
+        return loss_config
+
+    if isinstance(loss_config["regularization"], list):
+        # config up-to-date
         return loss_config
 
     if "energy_type" not in loss_config["regularization"]:

--- a/deepreg/model/network.py
+++ b/deepreg/model/network.py
@@ -188,11 +188,11 @@ class RegistrationModel(tf.keras.Model):
             )
             return
 
-        loss_list = self.config["loss"][name]
-        if not isinstance(loss_list, list):
-            loss_list = [loss_list]
+        loss_configs = self.config["loss"][name]
+        if not isinstance(loss_configs, list):
+            loss_configs = [loss_configs]
 
-        for loss_config in loss_list:
+        for loss_config in loss_configs:
 
             if "weight" not in loss_config:
                 # default loss weight 1

--- a/deepreg/model/network.py
+++ b/deepreg/model/network.py
@@ -62,6 +62,7 @@ class RegistrationModel(tf.keras.Model):
 
         self._inputs = None  # save inputs of self._model as dict
         self._outputs = None  # save outputs of self._model as dict
+
         self._model = self.build_model()
         self.build_loss()
 
@@ -178,6 +179,7 @@ class RegistrationModel(tf.keras.Model):
         :param name: name of loss
         :param inputs_dict: inputs for loss function
         """
+
         if name not in self.config["loss"]:
             # loss config is not defined
             logging.warning(
@@ -186,39 +188,47 @@ class RegistrationModel(tf.keras.Model):
             )
             return
 
-        loss_config = self.config["loss"][name]
+        loss_list = self.config["loss"][name]
+        if not isinstance(loss_list, list):
+            loss_list = [loss_list]
 
-        if "weight" not in loss_config:
-            # default loss weight 1
-            logging.warning(
-                f"The weight for loss {name} is not defined."
-                f"Default weight = 1.0 is used."
+        for loss_config in loss_list:
+
+            if "weight" not in loss_config:
+                # default loss weight 1
+                logging.warning(
+                    f"The weight for loss {name} is not defined."
+                    f"Default weight = 1.0 is used."
+                )
+                loss_config["weight"] = 1.0
+
+            # build loss
+            weight = loss_config["weight"]
+
+            if weight == 0:
+                logging.warning(
+                    f"The weight for loss {name} is zero." f"Loss is not used."
+                )
+                return
+
+            loss_cls = REGISTRY.build_loss(
+                config=dict_without(d=loss_config, key="weight")
             )
-            loss_config["weight"] = 1.0
+            loss = loss_cls(**inputs_dict) / self.global_batch_size
+            weighted_loss = loss * weight
 
-        # build loss
-        weight = loss_config["weight"]
+            # add loss
+            self._model.add_loss(weighted_loss)
 
-        if weight == 0:
-            logging.warning(f"The weight for loss {name} is zero." f"Loss is not used.")
-            return
-
-        loss_cls = REGISTRY.build_loss(config=dict_without(d=loss_config, key="weight"))
-        loss = loss_cls(**inputs_dict) / self.global_batch_size
-        weighted_loss = loss * weight
-
-        # add loss
-        self._model.add_loss(weighted_loss)
-
-        # add metric
-        self._model.add_metric(
-            loss, name=f"loss/{name}_{loss_cls.name}", aggregation="mean"
-        )
-        self._model.add_metric(
-            weighted_loss,
-            name=f"loss/{name}_{loss_cls.name}_weighted",
-            aggregation="mean",
-        )
+            # add metric
+            self._model.add_metric(
+                loss, name=f"loss/{name}_{loss_cls.name}", aggregation="mean"
+            )
+            self._model.add_metric(
+                weighted_loss,
+                name=f"loss/{name}_{loss_cls.name}_weighted",
+                aggregation="mean",
+            )
 
     @abstractmethod
     def build_loss(self):

--- a/docs/source/docs/configuration.md
+++ b/docs/source/docs/configuration.md
@@ -450,9 +450,10 @@ train:
       l1: false
 ```
 
-#### Multiple Losses
+#### Composite Loss
 
-Add multiple losses by putting all the fields in the same file.
+The loss function can be a composite of different loss categories by adding all fields
+in the same configuration file.
 
 ```yaml
 train:
@@ -468,6 +469,31 @@ train:
     label:
       weight: 1.0
       name: "dice"
+```
+
+Moreover, one may want to specify several loss functions for each category. In that
+case, a dashed line (-) indicates the specification of a new loss function under each
+field.
+
+E.G.
+
+```yaml
+train:
+  method: "ddf" # One of ddf, dvf, conditional
+  backbone:
+    name: "local" # One of unet, local, global
+    num_channel_initial: 16 # Int type, number of initial channels in the network. Controls the network size.
+    extract_levels: [0, 1, 2]
+  loss:
+    image:
+      - name: "lncc"
+        weight: 0.5
+        kernel_size: 5
+      - name: "gmi"
+        weight: 0.5
+    label:
+      name: "dice"
+      weight: 0.5
 ```
 
 ### Optimizer - required

--- a/test/unit/test_config_v011.py
+++ b/test/unit/test_config_v011.py
@@ -124,7 +124,7 @@ class TestParseImageLoss:
             ],
         }
 
-        got = parse_reg_loss(loss_config=loss_config)
+        got = parse_image_loss(loss_config=loss_config)
         assert got == loss_config
 
 
@@ -187,7 +187,7 @@ class TestParseLabelLoss:
             ],
         }
 
-        got = parse_reg_loss(loss_config=loss_config)
+        got = parse_label_loss(loss_config=loss_config)
         assert got == loss_config
 
 

--- a/test/unit/test_network.py
+++ b/test/unit/test_network.py
@@ -36,6 +36,13 @@ config = {
     },
 }
 
+config_multiple_losses = deepcopy(config)
+config_multiple_losses["loss"]["image"] = [
+    {"name": "lncc", "weight": 0.1},
+    {"name": "ssd", "weight": 0.1},
+    {"name": "gmi", "weight": 0.1},
+]
+
 
 @pytest.fixture
 def model(method: str, labeled: bool, backbone: str) -> RegistrationModel:
@@ -160,12 +167,13 @@ class TestRegistrationModel:
 
 class TestBuildLoss:
     params = [
-        dict(option=0, expected=2),
-        dict(option=1, expected=2),
-        dict(option=2, expected=3),
+        dict(config=config, option=0, expected=2),
+        dict(config=config, option=1, expected=2),
+        dict(config=config, option=2, expected=3),
+        dict(config=config_multiple_losses, option=3, expected=5),
     ]
 
-    def test_no_image_loss(self, option: int, expected: int):
+    def test_image_loss(self, config: dict, option: int, expected: int):
         method = "ddf"
         backbone = "local"
         labeled = True
@@ -180,7 +188,7 @@ class TestBuildLoss:
         elif option == 1:
             # set image loss weight to zero, so loss is not used
             copied["loss"]["image"]["weight"] = 0.0
-        else:
+        elif option == 2:
             # remove image loss weight, so loss is used with default weight 1
             copied["loss"]["image"].pop("weight")
 


### PR DESCRIPTION
# Description

Support the specification of >1 loss functions for each loss type "image", "label", "regularization". I'm not sure it make sense to use multiple loss functions for regularization but anyway it's done.

A config file example is:
```
loss:
  "image"
      - "name": "ssd"
         "weight": 0.5
      - "name": "lncc"
         "weight": 0.5
  "label"
       "name": "cross-entropy"
       "weight": 1.0
  "regularization":
        "name": "bending"
        "weight": 0.1
...
```
      
Fixes #526 

## Type of change

What types of changes does your code introduce to DeepReg?

_Please check the boxes that apply after submitting the pull request._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation Update (fix or improvement on the documentation)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (if none of the other choices apply)

## Checklist

_Please check the boxes that apply after submitting the pull request._

_If you're unsure about any of them, don't hesitate to ask. We're here to help! This is
simply a reminder of what we are going to look for before merging your code._

- [X] I have
      [installed pre-commit](https://deepreg.readthedocs.io/en/latest/contributing/setup.html)
      using `pre-commit install` and formatted all changed files. If you are not
      certain, run `pre-commit run --all-files`.
- [X] My commits' message styles matches
      [our requested structure](https://deepreg.readthedocs.io/en/latest/contributing/commit.html),
      e.g. `Issue #<issue number>: detailed message`.
- [X] I have updated the
      [change log file](https://github.com/DeepRegNet/DeepReg/blob/main/CHANGELOG.md)
      regarding my changes.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
