### PR TITLE
BSplines interp. independent of the backbone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ compatible with the updates.
 
 ### Changed
 
-- tba
+- Refactored BSplines interpolation independetly of the backbone network and available
+  only for DDF and DVF models.
 
 ### Fixed
 

--- a/deepreg/model/backbone/local_net.py
+++ b/deepreg/model/backbone/local_net.py
@@ -36,7 +36,6 @@ class LocalNet(Backbone):
         extract_levels: List[int],
         out_kernel_initializer: str,
         out_activation: str,
-        control_points: (tuple, None) = None,
         name: str = "LocalNet",
         **kwargs,
     ):
@@ -54,7 +53,6 @@ class LocalNet(Backbone):
         :param extract_levels: number of extraction levels.
         :param out_kernel_initializer: initializer to use for kernels.
         :param out_activation: activation to use at end layer.
-        :param control_points: specify the distance between control points (in voxels).
         :param name: name of the backbone.
         :param kwargs: additional arguments.
         """
@@ -104,17 +102,6 @@ class LocalNet(Backbone):
             for _ in self._extract_levels
         ]
 
-        self.resize = (
-            layer.ResizeCPTransform(control_points)
-            if control_points is not None
-            else False
-        )
-        self.interpolate = (
-            layer.BSplines3DTransform(control_points, image_size)
-            if control_points is not None
-            else False
-        )
-
     def call(self, inputs: tf.Tensor, training=None, mask=None) -> tf.Tensor:
         """
         Build LocalNet graph based on built layers.
@@ -163,9 +150,5 @@ class LocalNet(Backbone):
             ),
             axis=5,
         )
-
-        if self.resize:
-            output = self.resize(output)
-            output = self.interpolate(output)
 
         return output

--- a/deepreg/model/backbone/u_net.py
+++ b/deepreg/model/backbone/u_net.py
@@ -31,7 +31,6 @@ class UNet(Backbone):
         out_activation: str,
         pooling: bool = True,
         concat_skip: bool = False,
-        control_points: (tuple, None) = None,
         name: str = "Unet",
         **kwargs,
     ):
@@ -48,7 +47,6 @@ class UNet(Backbone):
                         pooling if true, otherwise use conv3d
         :param concat_skip: when upsampling, concatenate skipped
                             tensor if true, otherwise use addition
-        :param control_points: specify the distance between control points (in voxels).
         :param name: name of the backbone.
         :param kwargs: additional arguments.
         """
@@ -82,17 +80,6 @@ class UNet(Backbone):
             filters=out_channels,
             kernel_initializer=out_kernel_initializer,
             activation=out_activation,
-        )
-
-        self.resize = (
-            layer.ResizeCPTransform(control_points)
-            if control_points is not None
-            else False
-        )
-        self.interpolate = (
-            layer.BSplines3DTransform(control_points, image_size)
-            if control_points is not None
-            else False
         )
 
     def call(self, inputs: tf.Tensor, training=None, mask=None) -> tf.Tensor:
@@ -129,9 +116,5 @@ class UNet(Backbone):
 
         # output
         output = self._output_conv3d(inputs=up_sampled)
-
-        if self.resize:
-            output = self.resize(output)
-            output = self.interpolate(output)
 
         return output

--- a/deepreg/model/network.py
+++ b/deepreg/model/network.py
@@ -265,6 +265,15 @@ class DDFModel(RegistrationModel):
     and a DDF is calculated based on that.
     """
 
+    def _resize_interpolate(self, field, control_points):
+        resize = layer.ResizeCPTransform(control_points)
+        field = resize(field)
+
+        interpolate = layer.BSplines3DTransform(control_points, self.fixed_image_size)
+        field = interpolate(field)
+
+        return field
+
     def build_model(self):
         """Build the model to be saved as self._model."""
         # build inputs
@@ -273,6 +282,7 @@ class DDFModel(RegistrationModel):
         fixed_image = self._inputs["fixed_image"]
 
         # build ddf
+        control_points = self.config["backbone"].pop("control_points", False)
         backbone_inputs = self.concat_images(moving_image, fixed_image)
         backbone = REGISTRY.build_backbone(
             config=self.config["backbone"],
@@ -291,6 +301,9 @@ class DDFModel(RegistrationModel):
         else:
             # (f_dim1, f_dim2, f_dim3, 3)
             ddf = backbone(inputs=backbone_inputs)
+            ddf = (
+                self._resize_interpolate(ddf, control_points) if control_points else ddf
+            )
             self._outputs = dict(ddf=ddf)
 
         # build outputs
@@ -388,6 +401,7 @@ class DVFModel(DDFModel):
         self._inputs = self.build_inputs()
         moving_image = self._inputs["moving_image"]
         fixed_image = self._inputs["fixed_image"]
+        control_points = self.config["backbone"].pop("control_points", False)
 
         # build ddf
         backbone_inputs = self.concat_images(moving_image, fixed_image)
@@ -401,6 +415,7 @@ class DVFModel(DDFModel):
             ),
         )
         dvf = backbone(inputs=backbone_inputs)
+        dvf = self._resize_interpolate(dvf, control_points) if control_points else dvf
         ddf = layer.IntDVF(fixed_image_size=self.fixed_image_size)(dvf)
 
         # build outputs

--- a/test/unit/test_backbone.py
+++ b/test/unit/test_backbone.py
@@ -123,10 +123,10 @@ class TestLocalNet:
     """
 
     @pytest.mark.parametrize(
-        "image_size,extract_levels,control_points",
-        [((1, 2, 3), [1, 2, 3], None), ((8, 8, 8), [1, 2, 3], (2, 2, 2))],
+        "image_size,extract_levels",
+        [((1, 2, 3), [1, 2, 3]), ((8, 8, 8), [1, 2, 3])],
     )
-    def test_init(self, image_size, extract_levels, control_points):
+    def test_init(self, image_size, extract_levels):
         network = loc.LocalNet(
             image_size=image_size,
             out_channels=3,
@@ -134,7 +134,6 @@ class TestLocalNet:
             extract_levels=extract_levels,
             out_kernel_initializer="he_normal",
             out_activation="softmax",
-            control_points=control_points,
         )
 
         # asserting initialised var for extract_levels is the same - Pass
@@ -169,17 +168,11 @@ class TestLocalNet:
         # assert number of upsample blocks is correct (== extract_levels), Pass
         assert len(network._extract_layers) == len(extract_levels)
 
-        if control_points is None:
-            assert network.resize is False
-        else:
-            assert isinstance(network.resize, layer.ResizeCPTransform)
-            assert isinstance(network.interpolate, layer.BSplines3DTransform)
-
     @pytest.mark.parametrize(
-        "image_size,extract_levels,control_points",
-        [((1, 2, 3), [1, 2, 3], None), ((8, 8, 8), [1, 2, 3], (2, 2, 2))],
+        "image_size,extract_levels",
+        [((1, 2, 3), [1, 2, 3]), ((8, 8, 8), [1, 2, 3])],
     )
-    def test_call(self, image_size, extract_levels, control_points):
+    def test_call(self, image_size, extract_levels):
         # initialising LocalNet instance
         network = loc.LocalNet(
             image_size=image_size,
@@ -188,7 +181,6 @@ class TestLocalNet:
             extract_levels=extract_levels,
             out_kernel_initializer="he_normal",
             out_activation="softmax",
-            control_points=control_points,
         )
 
         # pass an input of all zeros
@@ -209,10 +201,10 @@ class TestUNet:
     """
 
     @pytest.mark.parametrize(
-        "image_size,depth,control_points",
-        [((1, 2, 3), 5, None), ((8, 8, 8), 3, (2, 2, 2))],
+        "image_size,depth",
+        [((1, 2, 3), 5), ((8, 8, 8), 3)],
     )
-    def test_init(self, image_size, depth, control_points):
+    def test_init(self, image_size, depth):
         network = u.UNet(
             image_size=image_size,
             out_channels=3,
@@ -220,7 +212,6 @@ class TestUNet:
             depth=depth,
             out_kernel_initializer="he_normal",
             out_activation="softmax",
-            control_points=control_points,
         )
 
         # asserting num channels initial is the same, Pass
@@ -253,17 +244,11 @@ class TestUNet:
         # assert output_conv3d is correct type, Pass
         assert isinstance(network._output_conv3d, layer.Conv3dWithResize)
 
-        if control_points is None:
-            assert network.resize is False
-        else:
-            assert isinstance(network.resize, layer.ResizeCPTransform)
-            assert isinstance(network.interpolate, layer.BSplines3DTransform)
-
     @pytest.mark.parametrize(
-        "image_size,depth,control_points",
-        [((1, 2, 3), 5, None), ((8, 8, 8), 3, (2, 2, 2))],
+        "image_size,depth",
+        [((1, 2, 3), 5), ((8, 8, 8), 3)],
     )
-    def test_call_unet(self, image_size, depth, control_points):
+    def test_call_unet(self, image_size, depth):
         out = 3
         # initialising UNet instance
         network = u.UNet(
@@ -273,7 +258,6 @@ class TestUNet:
             depth=depth,
             out_kernel_initializer="he_normal",
             out_activation="softmax",
-            control_points=control_points,
         )
         # pass an input of all zeros
         inputs = tf.constant(

--- a/test/unit/test_network.py
+++ b/test/unit/test_network.py
@@ -22,9 +22,7 @@ backbone_args = {
     "unet": {"depth": 2},
 }
 config = {
-    "backbone": {
-        "num_channel_initial": 4,
-    },
+    "backbone": {"num_channel_initial": 4, "control_points": 2},
     "loss": {
         "image": {"name": "lncc", "weight": 0.1},
         "label": {
@@ -50,6 +48,8 @@ def model(method: str, labeled: bool, backbone: str) -> RegistrationModel:
     copied = deepcopy(config)
     copied["method"] = method
     copied["backbone"]["name"] = backbone
+    if method == "conditional":
+        copied["backbone"].pop("control_points", None)
     copied["backbone"] = {**backbone_args[backbone], **copied["backbone"]}
     return REGISTRY.build_model(
         config=dict(


### PR DESCRIPTION
# Description

Remove BSplines interpolation from being hard-coded in backbones. That will help in:
- When implementing new models, we won't need to add those lines
- It is model-dependent (DVF, DDF) and do no apply for others (e.g., conditional)

Fixes #645 

## Type of change

What types of changes does your code introduce to DeepReg?

_Please check the boxes that apply after submitting the pull request._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Documentation Update (fix or improvement on the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (if none of the other choices apply)

## Checklist

_Please check the boxes that apply after submitting the pull request._

_If you're unsure about any of them, don't hesitate to ask. We're here to help! This is
simply a reminder of what we are going to look for before merging your code._

- [X] I have
      [installed pre-commit](https://deepreg.readthedocs.io/en/latest/contributing/setup.html)
      using `pre-commit install` and formatted all changed files. If you are not
      certain, run `pre-commit run --all-files`.
- [X] My commits' message styles matches
      [our requested structure](https://deepreg.readthedocs.io/en/latest/contributing/commit.html),
      e.g. `Issue #<issue number>: detailed message`.
- [X] I have updated the
      [change log file](https://github.com/DeepRegNet/DeepReg/blob/main/CHANGELOG.md)
      regarding my changes.
- [X] I have added tests that prove my fix is effective or that my feature works
- [] I have added necessary documentation (if appropriate)
