### PR TITLE
Issue #613: remove loss weight check in sanity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ compatible with the updates.
 
 ### Fixed
 
+- Removed loss weight checks to be more robust.
 - Fixed the residual module in local net architecture, compatible for previous
   checkpoints.
 - Broken link in README to seminar video.

--- a/deepreg/config/parser.py
+++ b/deepreg/config/parser.py
@@ -109,17 +109,4 @@ def config_sanity_check(config: dict) -> dict:
                 "For conditional model, data have to be labeled, got unlabeled data."
             )
 
-    # loss weights should >= 0
-    for name in ["image", "label", "regularization"]:
-        loss_config = config["train"]["loss"][name]
-        if not isinstance(loss_config, list):
-            loss_config = [loss_config]
-
-        for loss_i in loss_config:
-            loss_weight = loss_i["weight"]
-            if loss_weight <= 0:
-                logging.warning(
-                    "The %s loss weight %.2f is not positive.", name, loss_weight
-                )
-
     return config

--- a/deepreg/model/network.py
+++ b/deepreg/model/network.py
@@ -182,8 +182,8 @@ class RegistrationModel(tf.keras.Model):
         if name not in self.config["loss"]:
             # loss config is not defined
             logging.warning(
-                f"The configuration for loss {name} is not defined."
-                f"Loss is not used."
+                f"The configuration for loss {name} is not defined. "
+                f"Therefore it is not used."
             )
             return
 

--- a/test/unit/test_config_parser.py
+++ b/test/unit/test_config_parser.py
@@ -213,6 +213,3 @@ def test_config_sanity_check(caplog):
     assert "Data directory for train is not defined." in caplog.text
     assert "Data directory for valid is not defined." in caplog.text
     assert "Data directory for test is not defined." in caplog.text
-    assert "The image loss weight 0.00 is not positive." in caplog.text
-    assert "The label loss weight 0.00 is not positive." in caplog.text
-    assert "The regularization loss weight 0.00 is not positive." in caplog.text


### PR DESCRIPTION
# Description

As now, `_build_loss` handles the checking and is quite robust. No more need to check losses in sanity checks.

https://github.com/DeepRegNet/DeepReg/blob/main/deepreg/model/network.py#L174

Fixes #613

## Type of change

What types of changes does your code introduce to DeepReg?

_Please check the boxes that apply after submitting the pull request._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation Update (fix or improvement on the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (if none of the other choices apply)

## Checklist

_Please check the boxes that apply after submitting the pull request._

_If you're unsure about any of them, don't hesitate to ask. We're here to help! This is
simply a reminder of what we are going to look for before merging your code._

- [x] I have
      [installed pre-commit](https://deepreg.readthedocs.io/en/latest/contributing/setup.html)
      using `pre-commit install` and formatted all changed files. If you are not
      certain, run `pre-commit run --all-files`.
- [x] My commits' message styles matches
      [our requested structure](https://deepreg.readthedocs.io/en/latest/contributing/commit.html),
      e.g. `Issue #<issue number>: detailed message`.
- [x] I have updated the
      [change log file](https://github.com/DeepRegNet/DeepReg/blob/main/CHANGELOG.md)
      regarding my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
